### PR TITLE
Add assertion for business list

### DIFF
--- a/src/test/controllers/businessControllers.test.ts
+++ b/src/test/controllers/businessControllers.test.ts
@@ -40,13 +40,17 @@ describe("Business Controllers Tests", () => {
 					],
 				},
 			];
-                        (businessService.getAll as jest.Mock).mockResolvedValue(mockBusinesses);
+                        (businessService.getAll as jest.Mock).mockResolvedValueOnce(mockBusinesses);
 
 			const response = await request(app).get("/api/v1/businesses");
 
                         expect(response.status).toBe(200);
                         expect(businessService.getAll).toHaveBeenCalled();
-                        expect(response.body.data).toEqual(mockBusinesses);
+                        expect(response.body).toEqual({
+                                success: true,
+                                message: "Businesses fetched successfully",
+                                data: mockBusinesses,
+                        });
                 });
         });
 

--- a/src/test/controllers/businessControllers.test.ts
+++ b/src/test/controllers/businessControllers.test.ts
@@ -1,9 +1,8 @@
 import request from "supertest";
+// Prevent database connection attempts when importing the app
+jest.mock("../../config/db");
 import app from "../../app";
-import { Business } from "../../models/Business";
 import { businessService } from "../../services/BusinessService";
-
-jest.mock("../../models/Business");
 
 jest.mock("../../services/BusinessService", () => ({
 	businessService: {
@@ -41,14 +40,15 @@ describe("Business Controllers Tests", () => {
 					],
 				},
 			];
-			(Business.find as jest.Mock).mockResolvedValue(mockBusinesses);
+                        (businessService.getAll as jest.Mock).mockResolvedValue(mockBusinesses);
 
 			const response = await request(app).get("/api/v1/businesses");
 
-			expect(response.status).toBe(200);
-			expect(businessService.getAll).toHaveBeenCalled();
-		});
-	});
+                        expect(response.status).toBe(200);
+                        expect(businessService.getAll).toHaveBeenCalled();
+                        expect(response.body.data).toEqual(mockBusinesses);
+                });
+        });
 
 	describe("Get business by id", () => {
 		it("should get business by id", async () => {

--- a/src/test/controllers/useControllers.test.ts
+++ b/src/test/controllers/useControllers.test.ts
@@ -1,4 +1,6 @@
 import request from "supertest";
+// Prevent database connection attempts when importing the app
+jest.mock("../../config/db");
 import app from "../../app";
 import { User, IUser } from "../../models/User";
 import UserService from "../../services/UserService";


### PR DESCRIPTION
## Summary
- mock DB connections in controller tests
- check controller returns mocked businesses

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_68423dc0c2c4832aa5c35c591c01de76