### PR TITLE
Check null user in update

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -127,11 +127,17 @@ class UserService extends BaseService {
 		return User.findById(userId);
 	}
 
-	async updateUserById(userId: string, updateData: Partial<IUser>) {
-		const user = await this.findUserById(userId);
-		this.updateUserFields(user, updateData);
-		return user.save();
-	}
+        async updateUserById(userId: string, updateData: Partial<IUser>) {
+                const user = await this.findUserById(userId);
+                if (!user) {
+                        throw new HttpError(
+                                HttpStatusCode.NOT_FOUND,
+                                getErrorMessage("User not found")
+                        );
+                }
+                this.updateUserFields(user, updateData);
+                return user.save();
+        }
 
 	async deleteUserById(userId: string) {
 		await User.findByIdAndDelete(userId);

--- a/src/test/services/userService.test.ts
+++ b/src/test/services/userService.test.ts
@@ -1,0 +1,17 @@
+import UserService from "../../services/UserService";
+import { HttpError, HttpStatusCode } from "../../types/Errors";
+import { IUser } from "../../models/User";
+
+describe("UserService updateUserById", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("should throw NotFound error when user does not exist", async () => {
+        jest.spyOn(UserService, "findUserById").mockResolvedValue(null as any);
+
+        await expect(UserService.updateUserById("1", {})).rejects.toThrow(
+            new HttpError(HttpStatusCode.NOT_FOUND, "Internal Server Error")
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- handle null users when updating
- add a test for the not-found branch

## Testing
- `npm run test:all --silent` *(fails: Error connecting to the database)*

------
https://chatgpt.com/codex/tasks/task_e_68423d40f944832a96b00f0f20ed1ab5