### PR TITLE
Add GeoService for geocoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"@googlemaps/google-maps-services-js": "^3.3.42",
 				"bcryptjs": "^2.4.3",
 				"body-parser": "^1.20.2",
 				"chai": "^5.0.3",
@@ -750,6 +751,28 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0",
 				"npm": ">=6.14.13"
+			}
+		},
+		"node_modules/@googlemaps/google-maps-services-js": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@googlemaps/google-maps-services-js/-/google-maps-services-js-3.4.1.tgz",
+			"integrity": "sha512-b9shxiSuKXfsWfUjAfmg1YUh1aN8tvuZ5DeKJxuZM+e2LQtuBRqbK6Xgd8OyQe55RsVk1EY4hhKZxlRlbLGT0g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@googlemaps/url-signature": "^1.0.4",
+				"agentkeepalive": "^4.1.0",
+				"axios": "^1.5.1",
+				"query-string": "<8.x",
+				"retry-axios": "<3.x"
+			}
+		},
+		"node_modules/@googlemaps/url-signature": {
+			"version": "1.0.40",
+			"resolved": "https://registry.npmjs.org/@googlemaps/url-signature/-/url-signature-1.0.40.tgz",
+			"integrity": "sha512-Gme3JxGZWQ4NVpATajSpS2/inQzhUxRvr/FK6IFpcC7AHOAmx8blI0y1/Qi2jqil+WoQ3TkEqq/MaKVtuV68RQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"crypto-js": "^4.2.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -1860,6 +1883,18 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/agentkeepalive": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1992,8 +2027,18 @@
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"node_modules/axios": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+			"integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
 		},
 		"node_modules/babel-jest": {
 			"version": "29.7.0",
@@ -2547,7 +2592,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
 			},
@@ -2720,6 +2764,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/crypto-js": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+			"integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+			"license": "MIT"
+		},
 		"node_modules/date-fns": {
 			"version": "2.30.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -2762,6 +2812,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decode-uri-component": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/dedent": {
@@ -2819,7 +2878,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -3486,6 +3544,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/finalhandler": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -3566,11 +3633,30 @@
 			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
 			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
 			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dev": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
@@ -3903,6 +3989,15 @@
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"engines": {
 				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.0.0"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -5895,6 +5990,12 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT"
+		},
 		"node_modules/pstree.remy": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -5936,6 +6037,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/query-string": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+			"integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+			"license": "MIT",
+			"dependencies": {
+				"decode-uri-component": "^0.2.2",
+				"filter-obj": "^1.1.0",
+				"split-on-first": "^1.0.0",
+				"strict-uri-encode": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -6083,6 +6202,18 @@
 			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/retry-axios": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
+			"integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.7.0"
+			},
+			"peerDependencies": {
+				"axios": "*"
 			}
 		},
 		"node_modules/reusify": {
@@ -6395,6 +6526,15 @@
 			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
 			"dev": true
 		},
+		"node_modules/split-on-first": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6433,6 +6573,15 @@
 			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/strict-uri-encode": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+			"integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
 		"mongodb": "^6.3.0",
 		"mongoose": "^8.0.2",
 		"morgan": "^1.10.0",
-		"nodemailer": "^6.9.13",
-		"ts-jest": "^29.1.2",
-		"winston": "^3.11.0"
+                "nodemailer": "^6.9.13",
+                "@googlemaps/google-maps-services-js": "^3.3.42",
+                "ts-jest": "^29.1.2",
+                "winston": "^3.11.0"
 	},
 	"devDependencies": {
 		"@faker-js/faker": "^8.4.1",

--- a/src/services/GeoService.ts
+++ b/src/services/GeoService.ts
@@ -14,18 +14,23 @@ export class GeoService {
                         throw new Error("Google Maps API key is not configured");
                 }
 
-                const response = await this.client.geocode({
-                        params: {
-                                address,
-                                key: this.apiKey,
-                        },
-                });
+                try {
+                        const response = await this.client.geocode({
+                                params: {
+                                        address,
+                                        key: this.apiKey,
+                                },
+                        });
 
-                const result = response.data.results[0];
-                if (!result) return null;
+                        const result = response.data.results[0];
+                        if (!result) return null;
 
-                const { lat, lng } = result.geometry.location;
-                return { lat, lng };
+                        const { lat, lng } = result.geometry.location;
+                        return { lat, lng };
+                } catch (error) {
+                        console.error("Error during geocoding:", error);
+                        return null;
+                }
         }
 }
 

--- a/src/services/GeoService.ts
+++ b/src/services/GeoService.ts
@@ -1,4 +1,5 @@
 import { Client } from "@googlemaps/google-maps-services-js";
+import logger from "../utils/logger";
 
 export class GeoService {
         readonly client: Client;
@@ -28,8 +29,10 @@ export class GeoService {
                         const { lat, lng } = result.geometry.location;
                         return { lat, lng };
                 } catch (error) {
-                        console.error("Error during geocoding:", error);
-                        return null;
+                        logger.error("Error during geocoding", {
+                                error: error instanceof Error ? error.message : String(error),
+                        });
+                        throw error;
                 }
         }
 }

--- a/src/services/GeoService.ts
+++ b/src/services/GeoService.ts
@@ -1,12 +1,12 @@
 import { Client } from "@googlemaps/google-maps-services-js";
 
-class GeoService {
-        private client: Client;
-        private apiKey: string;
+export class GeoService {
+        readonly client: Client;
+        readonly apiKey: string;
 
-        constructor() {
-                this.client = new Client({});
-                this.apiKey = process.env.GOOGLE_MAPS_API_KEY as string;
+        constructor(client: Client = new Client({}), apiKey: string = process.env.GOOGLE_MAPS_API_KEY as string) {
+                this.client = client;
+                this.apiKey = apiKey;
         }
 
         async geocodeAddress(address: string): Promise<{ lat: number; lng: number } | null> {

--- a/src/services/GeoService.ts
+++ b/src/services/GeoService.ts
@@ -1,0 +1,33 @@
+import { Client } from "@googlemaps/google-maps-services-js";
+
+class GeoService {
+        private client: Client;
+        private apiKey: string;
+
+        constructor() {
+                this.client = new Client({});
+                this.apiKey = process.env.GOOGLE_MAPS_API_KEY as string;
+        }
+
+        async geocodeAddress(address: string): Promise<{ lat: number; lng: number } | null> {
+                if (!this.apiKey) {
+                        throw new Error("Google Maps API key is not configured");
+                }
+
+                const response = await this.client.geocode({
+                        params: {
+                                address,
+                                key: this.apiKey,
+                        },
+                });
+
+                const result = response.data.results[0];
+                if (!result) return null;
+
+                const { lat, lng } = result.geometry.location;
+                return { lat, lng };
+        }
+}
+
+export const geoService = new GeoService();
+export default geoService;

--- a/src/test/services/geoService.test.ts
+++ b/src/test/services/geoService.test.ts
@@ -1,0 +1,30 @@
+import { Client } from "@googlemaps/google-maps-services-js";
+import { GeoService } from "../../services/GeoService";
+
+describe("GeoService", () => {
+    it("geocodeAddress returns lat/lng", async () => {
+        const geocode = jest.fn().mockResolvedValue({
+            data: {
+                results: [{ geometry: { location: { lat: 10, lng: 20 } } }]
+            }
+        });
+        const mockClient = { geocode } as unknown as Client;
+        const service = new GeoService(mockClient, "test-key");
+
+        const result = await service.geocodeAddress("test");
+
+        expect(geocode).toHaveBeenCalledWith({
+            params: { address: "test", key: "test-key" }
+        });
+        expect(result).toEqual({ lat: 10, lng: 20 });
+    });
+
+    it("returns null when no results", async () => {
+        const geocode = jest.fn().mockResolvedValue({ data: { results: [] } });
+        const mockClient = { geocode } as unknown as Client;
+        const service = new GeoService(mockClient, "test-key");
+
+        const result = await service.geocodeAddress("missing");
+        expect(result).toBeNull();
+    });
+});

--- a/src/test/services/geoService.test.ts
+++ b/src/test/services/geoService.test.ts
@@ -8,8 +8,8 @@ describe("GeoService", () => {
                 results: [{ geometry: { location: { lat: 10, lng: 20 } } }]
             }
         });
-        const mockClient = { geocode } as unknown as Client;
-        const service = new GeoService(mockClient, "test-key");
+        const mockClient: Partial<Client> = { geocode };
+        const service = new GeoService(mockClient as Client, "test-key");
 
         const result = await service.geocodeAddress("test");
 
@@ -21,8 +21,8 @@ describe("GeoService", () => {
 
     it("returns null when no results", async () => {
         const geocode = jest.fn().mockResolvedValue({ data: { results: [] } });
-        const mockClient = { geocode } as unknown as Client;
-        const service = new GeoService(mockClient, "test-key");
+        const mockClient: Partial<Client> = { geocode };
+        const service = new GeoService(mockClient as Client, "test-key");
 
         const result = await service.geocodeAddress("missing");
         expect(result).toBeNull();


### PR DESCRIPTION
## Summary
- implement new `GeoService` using `@googlemaps/google-maps-services-js`
- provide `geocodeAddress` method returning latitude and longitude
- expose singleton `geoService`
- add google maps library to dependencies

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_68433ebe4394832aa56da0d370dfac44