### PR TITLE
Add geospatial location to core models

### DIFF
--- a/src/models/Business.ts
+++ b/src/models/Business.ts
@@ -3,15 +3,19 @@ import mongoose, { Schema, Types, Document } from "mongoose";
 import { IContact } from "../types/modalTypes";
 
 export interface IBusiness extends Document {
-	_id: string;
-	namePlace: string;
-	author: Types.ObjectId;
-	address: string;
-	image: string;
-	contact: IContact[];
-	budget: number;
-	typeBusiness: string;
-	hours: [Date];
+        _id: string;
+        namePlace: string;
+        author: Types.ObjectId;
+        address: string;
+        location?: {
+                type: string;
+                coordinates: number[];
+        };
+        image: string;
+        contact: IContact[];
+        budget: number;
+        typeBusiness: string;
+        hours: [Date];
 	reviews: Types.ObjectId[];
 	rating: number;
 	numReviews: number;
@@ -28,15 +32,19 @@ const businessSchema: Schema = new mongoose.Schema<IBusiness>(
 			required: true,
 			unique: true,
 		},
-		address: {
-			type: String,
-			required: true,
-		},
-		contact: [
-			{
-				phone: Number,
-				email: String,
-				facebook: String,
+                address: {
+                        type: String,
+                        required: true,
+                },
+                location: {
+                        type: { type: String, enum: ["Point"], default: "Point" },
+                        coordinates: [Number],
+                },
+                contact: [
+                        {
+                                phone: Number,
+                                email: String,
+                                facebook: String,
 				instagram: String,
 			},
 		],
@@ -76,7 +84,9 @@ const businessSchema: Schema = new mongoose.Schema<IBusiness>(
 			default: 0,
 		},
 	},
-	{ timestamps: true }
+        { timestamps: true }
 );
+
+businessSchema.index({ location: "2dsphere" });
 
 export const Business = mongoose.model<IBusiness>("Business", businessSchema);

--- a/src/models/Business.ts
+++ b/src/models/Business.ts
@@ -1,16 +1,14 @@
 import mongoose, { Schema, Types, Document } from "mongoose";
 
-import { IContact } from "../types/modalTypes";
+import { IContact, IGeoJSONPoint } from "../types/modalTypes";
+import { geoJSONPointSchema } from "./GeoJSON";
 
 export interface IBusiness extends Document {
         _id: string;
         namePlace: string;
         author: Types.ObjectId;
         address: string;
-        location?: {
-                type: string;
-                coordinates: number[];
-        };
+        location?: IGeoJSONPoint;
         image: string;
         contact: IContact[];
         budget: number;
@@ -36,10 +34,7 @@ const businessSchema: Schema = new mongoose.Schema<IBusiness>(
                         type: String,
                         required: true,
                 },
-                location: {
-                        type: { type: String, enum: ["Point"], default: "Point" },
-                        coordinates: [Number],
-                },
+                location: geoJSONPointSchema,
                 contact: [
                         {
                                 phone: Number,

--- a/src/models/Doctor.ts
+++ b/src/models/Doctor.ts
@@ -5,9 +5,13 @@ import { IContact } from "../types/modalTypes";
 export interface IDoctor extends Document {
 	_id: string;
 	doctorName: string;
-	author: Types.ObjectId;
-	address: string;
-	image: string;
+        author: Types.ObjectId;
+        address: string;
+        location?: {
+                type: string;
+                coordinates: number[];
+        };
+        image: string;
 	specialty: string;
 	contact: IContact[];
 	reviews: Types.ObjectId[];
@@ -31,14 +35,18 @@ const doctorSchema = new Schema<IDoctor>(
 			ref: "User",
 			required: true,
 		},
-		address: {
-			type: String,
-			required: true,
-		},
-		image: {
-			type: String,
-			required: true,
-		},
+                address: {
+                        type: String,
+                        required: true,
+                },
+                location: {
+                        type: { type: String, enum: ["Point"], default: "Point" },
+                        coordinates: [Number],
+                },
+                image: {
+                        type: String,
+                        required: true,
+                },
 		specialty: {
 			type: String,
 			required: true,
@@ -85,4 +93,5 @@ const doctorSchema = new Schema<IDoctor>(
 	},
 	{ timestamps: true }
 );
+doctorSchema.index({ location: "2dsphere" });
 export const Doctor = mongoose.model<IDoctor>("Doctor", doctorSchema);

--- a/src/models/Doctor.ts
+++ b/src/models/Doctor.ts
@@ -1,16 +1,14 @@
 import mongoose, { Schema, Types, Document } from "mongoose";
 
-import { IContact } from "../types/modalTypes";
+import { IContact, IGeoJSONPoint } from "../types/modalTypes";
+import { geoJSONPointSchema } from "./GeoJSON";
 
 export interface IDoctor extends Document {
 	_id: string;
 	doctorName: string;
         author: Types.ObjectId;
         address: string;
-        location?: {
-                type: string;
-                coordinates: number[];
-        };
+        location?: IGeoJSONPoint;
         image: string;
 	specialty: string;
 	contact: IContact[];
@@ -39,10 +37,7 @@ const doctorSchema = new Schema<IDoctor>(
                         type: String,
                         required: true,
                 },
-                location: {
-                        type: { type: String, enum: ["Point"], default: "Point" },
-                        coordinates: [Number],
-                },
+                location: geoJSONPointSchema,
                 image: {
                         type: String,
                         required: true,

--- a/src/models/GeoJSON.ts
+++ b/src/models/GeoJSON.ts
@@ -1,0 +1,15 @@
+export interface IGeoJSONPoint {
+    type: 'Point';
+    coordinates: [number, number];
+}
+
+export const geoJSONPointSchema = {
+    type: { type: String, enum: ['Point'], default: 'Point' },
+    coordinates: {
+        type: [Number],
+        validate: {
+            validator: (value: number[]) => value.length === 2,
+            message: 'Coordinates must contain exactly two elements: [longitude, latitude].',
+        },
+    },
+};

--- a/src/models/Market.ts
+++ b/src/models/Market.ts
@@ -1,14 +1,13 @@
 import mongoose, { Schema, Types, Document } from "mongoose";
+import { IGeoJSONPoint } from "../types/modalTypes";
+import { geoJSONPointSchema } from "./GeoJSON";
 
 export interface IMarket extends Document {
 	_id: string;
 	marketName: string;
         author: Types.ObjectId;
         address: string;
-        location?: {
-                type: string;
-                coordinates: number[];
-        };
+        location?: IGeoJSONPoint;
         image: string;
 	typeMarket: string;
 	reviews: Types.ObjectId[];
@@ -36,10 +35,7 @@ const marketSchema = new Schema<IMarket>(
                         type: String,
                         required: true,
                 },
-                location: {
-                        type: { type: String, enum: ["Point"], default: "Point" },
-                        coordinates: [Number],
-                },
+                location: geoJSONPointSchema,
                 image: {
                         type: String,
                         required: true,

--- a/src/models/Market.ts
+++ b/src/models/Market.ts
@@ -3,9 +3,13 @@ import mongoose, { Schema, Types, Document } from "mongoose";
 export interface IMarket extends Document {
 	_id: string;
 	marketName: string;
-	author: Types.ObjectId;
-	address: string;
-	image: string;
+        author: Types.ObjectId;
+        address: string;
+        location?: {
+                type: string;
+                coordinates: number[];
+        };
+        image: string;
 	typeMarket: string;
 	reviews: Types.ObjectId[];
 	rating: number;
@@ -28,14 +32,18 @@ const marketSchema = new Schema<IMarket>(
 			ref: "User",
 			required: true,
 		},
-		address: {
-			type: String,
-			required: true,
-		},
-		image: {
-			type: String,
-			required: true,
-		},
+                address: {
+                        type: String,
+                        required: true,
+                },
+                location: {
+                        type: { type: String, enum: ["Point"], default: "Point" },
+                        coordinates: [Number],
+                },
+                image: {
+                        type: String,
+                        required: true,
+                },
 		typeMarket: {
 			type: String,
 			required: true,
@@ -60,5 +68,6 @@ const marketSchema = new Schema<IMarket>(
 	},
 	{ timestamps: true }
 );
+marketSchema.index({ location: "2dsphere" });
 
 export const Market = mongoose.model<IMarket>("Market", marketSchema);

--- a/src/models/Restaurant.ts
+++ b/src/models/Restaurant.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, Types, Document } from "mongoose";
 
-import { IContact } from "../types/modalTypes";
+import { IContact, IGeoJSONPoint } from "../types/modalTypes";
+import { geoJSONPointSchema } from "./GeoJSON";
 
 export interface IRestaurant extends Document {
 	_id: string;
@@ -8,10 +9,7 @@ export interface IRestaurant extends Document {
 	author: Types.ObjectId;
         typePlace: string;
         address: string;
-        location?: {
-                type: string;
-                coordinates: number[];
-        };
+        location?: IGeoJSONPoint;
         image: string;
 	budget: string;
 	contact: IContact[];
@@ -36,10 +34,7 @@ const restaurantSchema: Schema = new mongoose.Schema<IRestaurant>(
                         type: String,
                         required: true,
                 },
-                location: {
-                        type: { type: String, enum: ["Point"], default: "Point" },
-                        coordinates: [Number],
-                },
+                location: geoJSONPointSchema,
                 author: {
                         type: Schema.Types.ObjectId,
                         ref: "User",

--- a/src/models/Restaurant.ts
+++ b/src/models/Restaurant.ts
@@ -6,9 +6,13 @@ export interface IRestaurant extends Document {
 	_id: string;
 	restaurantName: string;
 	author: Types.ObjectId;
-	typePlace: string;
-	address: string;
-	image: string;
+        typePlace: string;
+        address: string;
+        location?: {
+                type: string;
+                coordinates: number[];
+        };
+        image: string;
 	budget: string;
 	contact: IContact[];
 	cuisine: [string];
@@ -28,14 +32,18 @@ const restaurantSchema: Schema = new mongoose.Schema<IRestaurant>(
 			required: true,
 			unique: true,
 		},
-		address: {
-			type: String,
-			required: true,
-		},
-		author: {
-			type: Schema.Types.ObjectId,
-			ref: "User",
-			required: true,
+                address: {
+                        type: String,
+                        required: true,
+                },
+                location: {
+                        type: { type: String, enum: ["Point"], default: "Point" },
+                        coordinates: [Number],
+                },
+                author: {
+                        type: Schema.Types.ObjectId,
+                        ref: "User",
+                        required: true,
 		},
 		contact: [
 			{
@@ -72,5 +80,6 @@ const restaurantSchema: Schema = new mongoose.Schema<IRestaurant>(
 	},
 	{ timestamps: true }
 );
+restaurantSchema.index({ location: "2dsphere" });
 
 export const Restaurant = mongoose.model<IRestaurant>("Restaurant", restaurantSchema);

--- a/src/models/Sanctuary.ts
+++ b/src/models/Sanctuary.ts
@@ -1,16 +1,14 @@
 import mongoose, { Schema, Types, Document } from "mongoose";
 
-import { IAnimal, IContact } from "../types/modalTypes";
+import { IAnimal, IContact, IGeoJSONPoint } from "../types/modalTypes";
+import { geoJSONPointSchema } from "./GeoJSON";
 
 export interface ISanctuary extends Document {
 	_id: string;
 	sanctuaryName: string;
         author: Types.ObjectId;
         address?: string;
-        location?: {
-                type: string;
-                coordinates: number[];
-        };
+        location?: IGeoJSONPoint;
         image: string;
 	typeofSanctuary: string;
 	animals: IAnimal[];
@@ -41,10 +39,7 @@ const sanctuarySchema = new Schema<ISanctuary>(
                 address: {
                         type: String,
                 },
-                location: {
-                        type: { type: String, enum: ["Point"], default: "Point" },
-                        coordinates: [Number],
-                },
+                location: geoJSONPointSchema,
                 image: {
                         type: String,
                         required: true,

--- a/src/models/Sanctuary.ts
+++ b/src/models/Sanctuary.ts
@@ -5,9 +5,13 @@ import { IAnimal, IContact } from "../types/modalTypes";
 export interface ISanctuary extends Document {
 	_id: string;
 	sanctuaryName: string;
-	author: Types.ObjectId;
-	address?: string;
-	image: string;
+        author: Types.ObjectId;
+        address?: string;
+        location?: {
+                type: string;
+                coordinates: number[];
+        };
+        image: string;
 	typeofSanctuary: string;
 	animals: IAnimal[];
 	capacity: number;
@@ -34,13 +38,17 @@ const sanctuarySchema = new Schema<ISanctuary>(
 			ref: "User",
 			required: true,
 		},
-		address: {
-			type: String,
-		},
-		image: {
-			type: String,
-			required: true,
-		},
+                address: {
+                        type: String,
+                },
+                location: {
+                        type: { type: String, enum: ["Point"], default: "Point" },
+                        coordinates: [Number],
+                },
+                image: {
+                        type: String,
+                        required: true,
+                },
 		typeofSanctuary: {
 			type: String,
 			required: true,
@@ -134,4 +142,5 @@ const sanctuarySchema = new Schema<ISanctuary>(
 	},
 	{ timestamps: true }
 );
+sanctuarySchema.index({ location: "2dsphere" });
 export const Sanctuary = mongoose.model<ISanctuary>("sanctuary", sanctuarySchema);

--- a/src/types/modalTypes.ts
+++ b/src/types/modalTypes.ts
@@ -69,3 +69,8 @@ export interface IAnimal {
 	vaccines: string[];
 	lastVaccine?: Date;
 }
+
+export interface IGeoJSONPoint {
+        type: 'Point';
+        coordinates: [number, number];
+}


### PR DESCRIPTION
## Summary
- include `location` field for Business, Doctor, Market, Restaurant and Sanctuary
- create 2dsphere indexes for spatial queries

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_6843466eba68832ab0bbeffb0454d1af