### PR TITLE
Add geocoding during create/update

### DIFF
--- a/src/controllers/businessControllers.ts
+++ b/src/controllers/businessControllers.ts
@@ -5,6 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { businessService as BusinessService } from "../services/BusinessService";
 import { reviewService as ReviewService } from "../services/ReviewService";
+import geoService from "../services/GeoService";
 
 /**
  * @description Get all businesses
@@ -71,8 +72,17 @@ export const createBusiness = asyncHandler(
 			);
 		}
 
-		try {
-			const business = await BusinessService.create(req.body);
+        try {
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const business = await BusinessService.create(req.body);
 			res.status(201).json({
 				success: true,
 				message: "Business created successfully",
@@ -100,9 +110,18 @@ export const updateBusiness = asyncHandler(
 				new HttpError(HttpStatusCode.BAD_REQUEST, getErrorMessage(errors.array()[0].msg))
 			);
 		}
-		try {
-			const { id } = req.params;
-			const updatedBusiness = await BusinessService.updateById(id, req.body);
+                try {
+                        const { id } = req.params;
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const updatedBusiness = await BusinessService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,
 				message: "Business updated successfully",

--- a/src/controllers/businessControllers.ts
+++ b/src/controllers/businessControllers.ts
@@ -5,7 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { businessService as BusinessService } from "../services/BusinessService";
 import { reviewService as ReviewService } from "../services/ReviewService";
-import geoService from "../services/GeoService";
+import geocodeAndAssignLocation from "../utils/geocodeLocation";
 
 /**
  * @description Get all businesses
@@ -72,17 +72,9 @@ export const createBusiness = asyncHandler(
 			);
 		}
 
-        try {
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
-                        const business = await BusinessService.create(req.body);
+       try {
+                        await geocodeAndAssignLocation(req.body);
+                       const business = await BusinessService.create(req.body);
 			res.status(201).json({
 				success: true,
 				message: "Business created successfully",
@@ -112,16 +104,8 @@ export const updateBusiness = asyncHandler(
 		}
                 try {
                         const { id } = req.params;
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
-                        const updatedBusiness = await BusinessService.updateById(id, req.body);
+                        await geocodeAndAssignLocation(req.body);
+                       const updatedBusiness = await BusinessService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,
 				message: "Business updated successfully",

--- a/src/controllers/doctorsControllers.ts
+++ b/src/controllers/doctorsControllers.ts
@@ -5,7 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { doctorService as DoctorService } from "../services/DoctorService";
 import { reviewService as ReviewService } from "../services/ReviewService";
-import geoService from "../services/GeoService";
+import geocodeAndAssignLocation from "../utils/geocodeLocation";
 
 /**
  * @description Get all doctors
@@ -71,15 +71,7 @@ export const createDoctor = asyncHandler(
 			);
 		}
                 try {
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
+                        await geocodeAndAssignLocation(req.body);
                         const doctor = await DoctorService.create(req.body);
 			res.status(201).json({
 				success: true,
@@ -110,15 +102,7 @@ export const updateDoctor = asyncHandler(
 		}
                 try {
                         const { id } = req.params;
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
+                        await geocodeAndAssignLocation(req.body);
                         const doctor = await DoctorService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,

--- a/src/controllers/marketsControllers.ts
+++ b/src/controllers/marketsControllers.ts
@@ -5,7 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { marketsService as MarketsService } from "../services/MarketsService";
 import { reviewService as ReviewService } from "../services/ReviewService";
-import geoService from "../services/GeoService";
+import geocodeAndAssignLocation from "../utils/geocodeLocation";
 
 /**
  * @description Get all markets
@@ -71,15 +71,7 @@ export const createMarket = asyncHandler(
 			);
 		}
                 try {
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
+                        await geocodeAndAssignLocation(req.body);
                         const market = await MarketsService.create(req.body);
 			res.status(201).json({
 				success: true,
@@ -110,15 +102,7 @@ export const updateMarket = asyncHandler(
 		}
                 try {
                         const { id } = req.params;
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
+                        await geocodeAndAssignLocation(req.body);
                         const market = await MarketsService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,

--- a/src/controllers/marketsControllers.ts
+++ b/src/controllers/marketsControllers.ts
@@ -5,6 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { marketsService as MarketsService } from "../services/MarketsService";
 import { reviewService as ReviewService } from "../services/ReviewService";
+import geoService from "../services/GeoService";
 
 /**
  * @description Get all markets
@@ -69,8 +70,17 @@ export const createMarket = asyncHandler(
 				new HttpError(HttpStatusCode.BAD_REQUEST, getErrorMessage(errors.array()[0].msg))
 			);
 		}
-		try {
-			const market = await MarketsService.create(req.body);
+                try {
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const market = await MarketsService.create(req.body);
 			res.status(201).json({
 				success: true,
 				message: "Market created successfully",
@@ -98,9 +108,18 @@ export const updateMarket = asyncHandler(
 				new HttpError(HttpStatusCode.BAD_REQUEST, getErrorMessage(errors.array()[0].msg))
 			);
 		}
-		try {
-			const { id } = req.params;
-			const market = await MarketsService.updateById(id, req.body);
+                try {
+                        const { id } = req.params;
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const market = await MarketsService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,
 				message: "Market updated successfully",

--- a/src/controllers/restaurantControllers.ts
+++ b/src/controllers/restaurantControllers.ts
@@ -5,7 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { restaurantService as RestaurantService } from "../services/RestaurantService";
 import { reviewService as ReviewService } from "../services/ReviewService";
-import geoService from "../services/GeoService";
+import geocodeAndAssignLocation from "../utils/geocodeLocation";
 
 /**
  * @description Get all restaurants
@@ -72,15 +72,7 @@ export const createRestaurant = asyncHandler(
 			);
 		}
                 try {
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
+                        await geocodeAndAssignLocation(req.body);
                         const restaurant = await RestaurantService.create(req.body);
 			res.status(201).json({
 				success: true,
@@ -111,15 +103,7 @@ export const updateRestaurant = asyncHandler(
 		}
                 try {
                         const { id } = req.params;
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
+                        await geocodeAndAssignLocation(req.body);
                         const restaurant = await RestaurantService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,

--- a/src/controllers/restaurantControllers.ts
+++ b/src/controllers/restaurantControllers.ts
@@ -5,6 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { restaurantService as RestaurantService } from "../services/RestaurantService";
 import { reviewService as ReviewService } from "../services/ReviewService";
+import geoService from "../services/GeoService";
 
 /**
  * @description Get all restaurants
@@ -70,8 +71,17 @@ export const createRestaurant = asyncHandler(
 				new HttpError(HttpStatusCode.BAD_REQUEST, getErrorMessage(errors.array()[0].msg))
 			);
 		}
-		try {
-			const restaurant = await RestaurantService.create(req.body);
+                try {
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const restaurant = await RestaurantService.create(req.body);
 			res.status(201).json({
 				success: true,
 				message: "Restaurant created successfully",
@@ -99,9 +109,18 @@ export const updateRestaurant = asyncHandler(
 				new HttpError(HttpStatusCode.BAD_REQUEST, getErrorMessage(errors.array()[0].msg))
 			);
 		}
-		try {
-			const { id } = req.params;
-			const restaurant = await RestaurantService.updateById(id, req.body);
+                try {
+                        const { id } = req.params;
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const restaurant = await RestaurantService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,
 				message: "Restaurant updated successfully",

--- a/src/controllers/sanctuaryControllers.ts
+++ b/src/controllers/sanctuaryControllers.ts
@@ -5,6 +5,7 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { sanctuaryService as SanctuaryService } from "../services/SanctuaryService";
 import { reviewService as ReviewService } from "../services/ReviewService";
+import geoService from "../services/GeoService";
 
 /**
  * @description Get all santuaries
@@ -69,8 +70,17 @@ export const createSanctuary = asyncHandler(
 			);
 		}
 
-		try {
-			const sanctuary = await SanctuaryService.create(req.body);
+               try {
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const sanctuary = await SanctuaryService.create(req.body);
 			res.status(201).json({
 				success: true,
 				message: "sanctuary created successfully",
@@ -98,9 +108,18 @@ export const updateSanctuary = asyncHandler(
 			);
 		}
 
-		try {
-			const { id } = req.params;
-			const sanctuary = await SanctuaryService.updateById(id, req.body);
+               try {
+                       const { id } = req.params;
+                        if (req.body.address) {
+                                const coords = await geoService.geocodeAddress(req.body.address);
+                                if (coords) {
+                                        req.body.location = {
+                                                type: "Point",
+                                                coordinates: [coords.lng, coords.lat],
+                                        };
+                                }
+                        }
+                        const sanctuary = await SanctuaryService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,
 				message: "sanctuary updated successfully",

--- a/src/controllers/sanctuaryControllers.ts
+++ b/src/controllers/sanctuaryControllers.ts
@@ -9,7 +9,7 @@ import geocodeAndAssignLocation from "../utils/geocodeLocation";
 
 /**
  * @description Get all sanctuaries
- * @name getSantuaries
+ * @name getSanctuaries
  * @route GET /api/sanctuaries
  * @access Public
  * @returns {Promise<Response>}

--- a/src/controllers/sanctuaryControllers.ts
+++ b/src/controllers/sanctuaryControllers.ts
@@ -5,10 +5,10 @@ import { HttpError, HttpStatusCode } from "../types/Errors";
 import { getErrorMessage } from "../types/modalTypes";
 import { sanctuaryService as SanctuaryService } from "../services/SanctuaryService";
 import { reviewService as ReviewService } from "../services/ReviewService";
-import geoService from "../services/GeoService";
+import geocodeAndAssignLocation from "../utils/geocodeLocation";
 
 /**
- * @description Get all santuaries
+ * @description Get all sanctuaries
  * @name getSantuaries
  * @route GET /api/sanctuaries
  * @access Public
@@ -18,11 +18,11 @@ import geoService from "../services/GeoService";
 export const getSanctuaries = asyncHandler(
 	async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const santuaries = await SanctuaryService.getAll();
-			res.status(200).json({
-				success: true,
-				message: "Santuaries fetched successfully",
-				data: santuaries,
+                        const sanctuaries = await SanctuaryService.getAll();
+                        res.status(200).json({
+                                success: true,
+                                message: "Sanctuaries fetched successfully",
+                                data: sanctuaries,
 			});
 		} catch (error) {
 			next(new HttpError(HttpStatusCode.NOT_FOUND, getErrorMessage(error)));
@@ -71,16 +71,8 @@ export const createSanctuary = asyncHandler(
 		}
 
                try {
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
-                        const sanctuary = await SanctuaryService.create(req.body);
+                        await geocodeAndAssignLocation(req.body);
+                       const sanctuary = await SanctuaryService.create(req.body);
 			res.status(201).json({
 				success: true,
 				message: "sanctuary created successfully",
@@ -110,16 +102,8 @@ export const updateSanctuary = asyncHandler(
 
                try {
                        const { id } = req.params;
-                        if (req.body.address) {
-                                const coords = await geoService.geocodeAddress(req.body.address);
-                                if (coords) {
-                                        req.body.location = {
-                                                type: "Point",
-                                                coordinates: [coords.lng, coords.lat],
-                                        };
-                                }
-                        }
-                        const sanctuary = await SanctuaryService.updateById(id, req.body);
+                        await geocodeAndAssignLocation(req.body);
+                       const sanctuary = await SanctuaryService.updateById(id, req.body);
 			res.status(200).json({
 				success: true,
 				message: "sanctuary updated successfully",
@@ -189,11 +173,11 @@ export const addReviewToSanctuary = asyncHandler(
 export const getTopRatedSanctuaries = asyncHandler(
 	async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const topRatedSanctuary = await ReviewService.getTopRatedReviews("sanctuary");
-			res.status(200).json({
-				success: true,
-				message: "Top rated santuaries fetched successfully",
-				data: topRatedSanctuary,
+                        const topRatedSanctuary = await ReviewService.getTopRatedReviews("sanctuary");
+                        res.status(200).json({
+                                success: true,
+                                message: "Top rated sanctuaries fetched successfully",
+                                data: topRatedSanctuary,
 			});
 		} catch (error) {
 			next(new HttpError(HttpStatusCode.NOT_FOUND, getErrorMessage(error)));

--- a/src/test/controllers/businessControllers.test.ts
+++ b/src/test/controllers/businessControllers.test.ts
@@ -113,6 +113,23 @@ describe("Business Controllers Tests", () => {
                                 })
                         );
                 });
+
+                it("handles geocoding errors gracefully", async () => {
+                        (geoService.geocodeAddress as jest.Mock).mockRejectedValue(new Error("boom"));
+                        (businessService.create as jest.Mock).mockResolvedValue({ id: "1" });
+
+                        await request(app)
+                                .post("/api/v1/businesses/create")
+                                .send({ namePlace: "BoomCo", address: "explode" });
+
+                        expect(geoService.geocodeAddress).toHaveBeenCalledWith("explode");
+                        expect(businessService.create).toHaveBeenCalledWith(
+                                expect.objectContaining({
+                                        namePlace: "BoomCo",
+                                        address: "explode",
+                                })
+                        );
+                });
         });
 
         describe("Update business", () => {

--- a/src/test/controllers/businessControllers.test.ts
+++ b/src/test/controllers/businessControllers.test.ts
@@ -3,6 +3,21 @@ import request from "supertest";
 jest.mock("../../config/db");
 import app from "../../app";
 import { businessService } from "../../services/BusinessService";
+import geoService from "../../services/GeoService";
+
+jest.mock("../../services/GeoService", () => ({
+        __esModule: true,
+        default: { geocodeAddress: jest.fn() },
+}));
+
+jest.mock("../../middleware/authMiddleware", () => ({
+        protect: (req, res, next) => {
+                req.user = { id: "user", role: "admin" };
+                next();
+        },
+        admin: (req, res, next) => next(),
+        professional: (req, res, next) => next(),
+}));
 
 jest.mock("../../services/BusinessService", () => ({
 	businessService: {
@@ -54,12 +69,84 @@ describe("Business Controllers Tests", () => {
                 });
         });
 
-	describe("Get business by id", () => {
-		it("should get business by id", async () => {
-			const response = await request(app).get("/api/v1/businesses/mockBusinessId");
+        describe("Get business by id", () => {
+                it("should get business by id", async () => {
+                        const response = await request(app).get("/api/v1/businesses/mockBusinessId");
 
-			expect(response.status).toBe(200);
-			expect(businessService.findById).toHaveBeenCalledWith("mockBusinessId");
-		});
-	});
+                        expect(response.status).toBe(200);
+                        expect(businessService.findById).toHaveBeenCalledWith("mockBusinessId");
+                });
+        });
+
+        describe("Create business", () => {
+                it("sets location when geocoding succeeds", async () => {
+                        (geoService.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 10, lng: 20 });
+                        (businessService.create as jest.Mock).mockResolvedValue({ id: "1" });
+
+                        await request(app)
+                                .post("/api/v1/businesses/create")
+                                .send({ namePlace: "My Shop", address: "123 st" });
+
+                        expect(geoService.geocodeAddress).toHaveBeenCalledWith("123 st");
+                        expect(businessService.create).toHaveBeenCalledWith(
+                                expect.objectContaining({
+                                        namePlace: "My Shop",
+                                        address: "123 st",
+                                        location: { type: "Point", coordinates: [20, 10] },
+                                })
+                        );
+                });
+
+                it("leaves location unset when geocoding fails", async () => {
+                        (geoService.geocodeAddress as jest.Mock).mockResolvedValue(null);
+                        (businessService.create as jest.Mock).mockResolvedValue({ id: "1" });
+
+                        await request(app)
+                                .post("/api/v1/businesses/create")
+                                .send({ namePlace: "Shop", address: "bad" });
+
+                        expect(geoService.geocodeAddress).toHaveBeenCalledWith("bad");
+                        expect(businessService.create).toHaveBeenCalledWith(
+                                expect.objectContaining({
+                                        namePlace: "Shop",
+                                        address: "bad",
+                                })
+                        );
+                });
+        });
+
+        describe("Update business", () => {
+                it("geocodes updated address", async () => {
+                        (geoService.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 5, lng: 6 });
+                        (businessService.updateById as jest.Mock).mockResolvedValue({ id: "1" });
+
+                        await request(app)
+                                .put("/api/v1/businesses/update/1")
+                                .send({ address: "456 road" });
+
+                        expect(geoService.geocodeAddress).toHaveBeenCalledWith("456 road");
+                        expect(businessService.updateById).toHaveBeenCalledWith(
+                                "1",
+                                expect.objectContaining({
+                                        address: "456 road",
+                                        location: { type: "Point", coordinates: [6, 5] },
+                                })
+                        );
+                });
+
+                it("does not set location when geocoding returns null", async () => {
+                        (geoService.geocodeAddress as jest.Mock).mockResolvedValue(null);
+                        (businessService.updateById as jest.Mock).mockResolvedValue({ id: "1" });
+
+                        await request(app)
+                                .put("/api/v1/businesses/update/1")
+                                .send({ address: "no" });
+
+                        expect(geoService.geocodeAddress).toHaveBeenCalledWith("no");
+                        expect(businessService.updateById).toHaveBeenCalledWith(
+                                "1",
+                                expect.objectContaining({ address: "no" })
+                        );
+                });
+        });
 });

--- a/src/utils/geocodeLocation.ts
+++ b/src/utils/geocodeLocation.ts
@@ -1,5 +1,6 @@
 import geoService from "../services/GeoService";
 import { IGeoJSONPoint } from "../types/GeoJSON";
+import logger from "./logger";
 
 export interface IGeocodeBody {
     address?: string;
@@ -7,13 +8,19 @@ export interface IGeocodeBody {
 }
 export async function geocodeAndAssignLocation(body: IGeocodeBody): Promise<void> {
     if (body.address) {
-        const coords = await geoService.geocodeAddress(body.address);
-        if (coords) {
-            const location: IGeoJSONPoint = {
-                type: "Point",
-                coordinates: [coords.lng, coords.lat],
-            };
-            body.location = location;
+        try {
+            const coords = await geoService.geocodeAddress(body.address);
+            if (coords) {
+                const location: IGeoJSONPoint = {
+                    type: "Point",
+                    coordinates: [coords.lng, coords.lat],
+                };
+                body.location = location;
+            }
+        } catch (error) {
+            logger.error("Error geocoding address", {
+                error: error instanceof Error ? error.message : String(error),
+            });
         }
     }
 }

--- a/src/utils/geocodeLocation.ts
+++ b/src/utils/geocodeLocation.ts
@@ -1,0 +1,17 @@
+import geoService from "../services/GeoService";
+import { IGeoJSONPoint } from "../types/GeoJSON";
+
+export async function geocodeAndAssignLocation(body: any): Promise<void> {
+    if (body.address) {
+        const coords = await geoService.geocodeAddress(body.address);
+        if (coords) {
+            const location: IGeoJSONPoint = {
+                type: "Point",
+                coordinates: [coords.lng, coords.lat],
+            };
+            body.location = location;
+        }
+    }
+}
+
+export default geocodeAndAssignLocation;

--- a/src/utils/geocodeLocation.ts
+++ b/src/utils/geocodeLocation.ts
@@ -1,7 +1,11 @@
 import geoService from "../services/GeoService";
 import { IGeoJSONPoint } from "../types/GeoJSON";
 
-export async function geocodeAndAssignLocation(body: any): Promise<void> {
+export interface IGeocodeBody {
+    address?: string;
+    location?: IGeoJSONPoint;
+}
+export async function geocodeAndAssignLocation(body: IGeocodeBody): Promise<void> {
     if (body.address) {
         const coords = await geoService.geocodeAddress(body.address);
         if (coords) {


### PR DESCRIPTION
## Summary
- use `GeoService.geocodeAddress` in business, market, restaurant, doctor and sanctuary controllers
- save returned coordinates to the `location` field when an address is present

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_6843671fbdcc832a9d0d6963271d8bb4