### PR TITLE
refactor: adopt RESTful routes

### DIFF
--- a/src/controllers/postControllers.ts
+++ b/src/controllers/postControllers.ts
@@ -84,7 +84,7 @@ export const createPost = asyncHandler(
 /**
  * @description Update a post by id
  * @name updatePost
- * @route PUT /api/posts/update/:id
+ * @route PUT /api/posts/:id
  * @access Private
  * @returns {Promise<Response>}
  */

--- a/src/routes/businessRoutes.ts
+++ b/src/routes/businessRoutes.ts
@@ -13,9 +13,9 @@ const router = express.Router();
 
 router.get("/", getBusinesses);
 router.get("/:id", getBusinessById);
-router.post("/create", protect, createBusiness);
+router.post("/", protect, createBusiness);
 router.post("/add-review/:id", protect, addReviewToBusiness);
-router.put("/update/:id", protect, admin, updateBusiness);
-router.delete("/delete/:id", protect, admin, deleteBusiness);
+router.put("/:id", protect, admin, updateBusiness);
+router.delete("/:id", protect, admin, deleteBusiness);
 
 export default router;

--- a/src/routes/doctorsRoutes.ts
+++ b/src/routes/doctorsRoutes.ts
@@ -13,9 +13,9 @@ const router = express.Router();
 
 router.get("/", getDoctors);
 router.get("/:id", getDoctorById);
-router.post("/create", protect, createDoctor);
+router.post("/", protect, createDoctor);
 router.post("/add-review/:id", protect, addReviewToDoctor);
-router.put("/update/:id", protect, admin, updateDoctor);
-router.delete("/delete/:id", protect, admin, deleteDoctor);
+router.put("/:id", protect, admin, updateDoctor);
+router.delete("/:id", protect, admin, deleteDoctor);
 
 export default router;

--- a/src/routes/marketsRoutes.ts
+++ b/src/routes/marketsRoutes.ts
@@ -13,9 +13,9 @@ const router = express.Router();
 
 router.get("/", getMarkets);
 router.get("/:id", getMarketById);
-router.post("/create", protect, createMarket);
+router.post("/", protect, createMarket);
 router.post("/add-review/:id", protect, addReviewToMarket);
-router.put("/update/:id", protect, admin, updateMarket);
-router.delete("/delete/:id", protect, admin, deleteMarket);
+router.put("/:id", protect, admin, updateMarket);
+router.delete("/:id", protect, admin, deleteMarket);
 
 export default router;

--- a/src/routes/postRoutes.ts
+++ b/src/routes/postRoutes.ts
@@ -15,11 +15,11 @@ const router = express.Router();
 
 router.get("/", getPosts);
 router.get("/:id", getPostById);
-router.post("/create", protect, createPost);
+router.post("/", protect, createPost);
 router.post("/like/:id", protect, likePost);
 router.post("/unlike/:id", protect, unlikePost);
 router.post("/comment/:id", protect, addComment);
-router.put("/update/:id", protect, updatePost);
-router.delete("/delete/:id", protect, deletePost);
+router.put("/:id", protect, updatePost);
+router.delete("/:id", protect, deletePost);
 
 export default router;

--- a/src/routes/professionProfileRoutes.ts
+++ b/src/routes/professionProfileRoutes.ts
@@ -12,8 +12,8 @@ const router = express.Router();
 
 router.get("/", getProfessionsProfile);
 router.get("/:id", getProfessionProfileById);
-router.post("/create", protect, professional, createProfessionProfile);
-router.put("/update/:id", protect, professional, updateProfessionProfile);
-router.delete("/delete/:id", protect, professional, admin, deleteProfessionProfile);
+router.post("/", protect, professional, createProfessionProfile);
+router.put("/:id", protect, professional, updateProfessionProfile);
+router.delete("/:id", protect, professional, admin, deleteProfessionProfile);
 
 export default router;

--- a/src/routes/professionRoutes.ts
+++ b/src/routes/professionRoutes.ts
@@ -13,9 +13,9 @@ const router = express.Router();
 
 router.get("/", getProfessions);
 router.get("/:id", getProfessionById);
-router.post("/create", protect, createProfession);
+router.post("/", protect, createProfession);
 router.post("/add-review/:id", protect, addReviewToProfession);
-router.put("/update/:id", protect, admin, updateProfession);
-router.delete("/delete/:id", protect, admin, deleteProfession);
+router.put("/:id", protect, admin, updateProfession);
+router.delete("/:id", protect, admin, deleteProfession);
 
 export default router;

--- a/src/routes/recipesRoutes.ts
+++ b/src/routes/recipesRoutes.ts
@@ -13,9 +13,9 @@ const router = express.Router();
 
 router.get("/", getRecipes);
 router.get("/:id", getRecipeById);
-router.post("/create", protect, createRecipe);
+router.post("/", protect, createRecipe);
 router.post("/add-review/:id", protect, addReviewToRecipe);
-router.put("/update/:id", protect, admin, updateRecipe);
-router.delete("/delete/:id", protect, admin, deleteRecipe);
+router.put("/:id", protect, admin, updateRecipe);
+router.delete("/:id", protect, admin, deleteRecipe);
 
 export default router;

--- a/src/routes/restaurantRoutes.ts
+++ b/src/routes/restaurantRoutes.ts
@@ -13,9 +13,9 @@ const router = express.Router();
 
 router.get("/", getRestaurants);
 router.get("/:id", getRestaurantById);
-router.post("/create", protect, createRestaurant);
+router.post("/", protect, createRestaurant);
 router.post("/add-review/:id", protect, addReviewToRestaurant);
-router.put("/update/:id", protect, admin, updateRestaurant);
-router.delete("/delete/:id", protect, admin, deleteRestaurant);
+router.put("/:id", protect, admin, updateRestaurant);
+router.delete("/:id", protect, admin, deleteRestaurant);
 
 export default router;

--- a/src/routes/sanctuaryRoutes.ts
+++ b/src/routes/sanctuaryRoutes.ts
@@ -13,9 +13,9 @@ const router = express.Router();
 
 router.get("/", getSanctuaries);
 router.get("/:id", getSanctuaryById);
-router.post("/create", protect, createSanctuary);
+router.post("/", protect, createSanctuary);
 router.post("/add-review/:id", protect, addReviewToSanctuary);
-router.put("/update/:id", protect, admin, updateSanctuary);
-router.delete("/delete/:id", protect, admin, deleteSanctuary);
+router.put("/:id", protect, admin, updateSanctuary);
+router.delete("/:id", protect, admin, deleteSanctuary);
 
 export default router;

--- a/src/test/controllers/businessControllers.test.ts
+++ b/src/test/controllers/businessControllers.test.ts
@@ -83,9 +83,9 @@ describe("Business Controllers Tests", () => {
                         (geoService.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 10, lng: 20 });
                         (businessService.create as jest.Mock).mockResolvedValue({ id: "1" });
 
-                        await request(app)
-                                .post("/api/v1/businesses/create")
-                                .send({ namePlace: "My Shop", address: "123 st" });
+        await request(app)
+                .post("/api/v1/businesses")
+                .send({ namePlace: "My Shop", address: "123 st" });
 
                         expect(geoService.geocodeAddress).toHaveBeenCalledWith("123 st");
                         expect(businessService.create).toHaveBeenCalledWith(
@@ -101,9 +101,9 @@ describe("Business Controllers Tests", () => {
                         (geoService.geocodeAddress as jest.Mock).mockResolvedValue(null);
                         (businessService.create as jest.Mock).mockResolvedValue({ id: "1" });
 
-                        await request(app)
-                                .post("/api/v1/businesses/create")
-                                .send({ namePlace: "Shop", address: "bad" });
+        await request(app)
+                .post("/api/v1/businesses")
+                .send({ namePlace: "Shop", address: "bad" });
 
                         expect(geoService.geocodeAddress).toHaveBeenCalledWith("bad");
                         expect(businessService.create).toHaveBeenCalledWith(
@@ -118,9 +118,9 @@ describe("Business Controllers Tests", () => {
                         (geoService.geocodeAddress as jest.Mock).mockRejectedValue(new Error("boom"));
                         (businessService.create as jest.Mock).mockResolvedValue({ id: "1" });
 
-                        await request(app)
-                                .post("/api/v1/businesses/create")
-                                .send({ namePlace: "BoomCo", address: "explode" });
+        await request(app)
+                .post("/api/v1/businesses")
+                .send({ namePlace: "BoomCo", address: "explode" });
 
                         expect(geoService.geocodeAddress).toHaveBeenCalledWith("explode");
                         expect(businessService.create).toHaveBeenCalledWith(
@@ -137,9 +137,9 @@ describe("Business Controllers Tests", () => {
                         (geoService.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 5, lng: 6 });
                         (businessService.updateById as jest.Mock).mockResolvedValue({ id: "1" });
 
-                        await request(app)
-                                .put("/api/v1/businesses/update/1")
-                                .send({ address: "456 road" });
+        await request(app)
+                .put("/api/v1/businesses/1")
+                .send({ address: "456 road" });
 
                         expect(geoService.geocodeAddress).toHaveBeenCalledWith("456 road");
                         expect(businessService.updateById).toHaveBeenCalledWith(
@@ -155,9 +155,9 @@ describe("Business Controllers Tests", () => {
                         (geoService.geocodeAddress as jest.Mock).mockResolvedValue(null);
                         (businessService.updateById as jest.Mock).mockResolvedValue({ id: "1" });
 
-                        await request(app)
-                                .put("/api/v1/businesses/update/1")
-                                .send({ address: "no" });
+        await request(app)
+                .put("/api/v1/businesses/1")
+                .send({ address: "no" });
 
                         expect(geoService.geocodeAddress).toHaveBeenCalledWith("no");
                         expect(businessService.updateById).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- refactor business, doctor, market, restaurant, profession, profession profile, recipe, post and sanctuary routes to use RESTful patterns
- adjust tests for new endpoints
- fix JSDoc route for post update

## Testing
- `npm run test:all` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436d54c8b0832abc529e4b3b680864