### PR TITLE
Add support for legacy action routes

### DIFF
--- a/src/routes/doctorsRoutes.ts
+++ b/src/routes/doctorsRoutes.ts
@@ -13,9 +13,17 @@ const router = express.Router();
 
 router.get("/", getDoctors);
 router.get("/:id", getDoctorById);
+
+// For compatibility with older clients use explicit action paths
+router.post("/create", protect, createDoctor);
 router.post("/", protect, createDoctor);
+
 router.post("/add-review/:id", protect, addReviewToDoctor);
+
+router.put("/update/:id", protect, admin, updateDoctor);
 router.put("/:id", protect, admin, updateDoctor);
+
+router.delete("/delete/:id", protect, admin, deleteDoctor);
 router.delete("/:id", protect, admin, deleteDoctor);
 
 export default router;

--- a/src/routes/marketsRoutes.ts
+++ b/src/routes/marketsRoutes.ts
@@ -13,9 +13,17 @@ const router = express.Router();
 
 router.get("/", getMarkets);
 router.get("/:id", getMarketById);
+
+// Support explicit action routes in addition to RESTful ones
+router.post("/create", protect, createMarket);
 router.post("/", protect, createMarket);
+
 router.post("/add-review/:id", protect, addReviewToMarket);
+
+router.put("/update/:id", protect, admin, updateMarket);
 router.put("/:id", protect, admin, updateMarket);
+
+router.delete("/delete/:id", protect, admin, deleteMarket);
 router.delete("/:id", protect, admin, deleteMarket);
 
 export default router;

--- a/src/routes/restaurantRoutes.ts
+++ b/src/routes/restaurantRoutes.ts
@@ -13,9 +13,17 @@ const router = express.Router();
 
 router.get("/", getRestaurants);
 router.get("/:id", getRestaurantById);
+
+// Accept legacy style endpoints alongside RESTful routes
+router.post("/create", protect, createRestaurant);
 router.post("/", protect, createRestaurant);
+
 router.post("/add-review/:id", protect, addReviewToRestaurant);
+
+router.put("/update/:id", protect, admin, updateRestaurant);
 router.put("/:id", protect, admin, updateRestaurant);
+
+router.delete("/delete/:id", protect, admin, deleteRestaurant);
 router.delete("/:id", protect, admin, deleteRestaurant);
 
 export default router;


### PR DESCRIPTION
## Summary
- allow `/create`, `/update/:id` and `/delete/:id` routes for doctors, markets and restaurants

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_6843795eb43c832aa14df04b4d8d5509