### PR TITLE
Add PostService and ReviewService tests

### DIFF
--- a/src/test/services/postService.test.ts
+++ b/src/test/services/postService.test.ts
@@ -1,0 +1,57 @@
+import { postService } from "../../services/PostService";
+import { HttpError } from "../../types/Errors";
+
+describe("PostService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("likes a post when not already liked", async () => {
+    const save = jest.fn();
+    const post = { likes: [], save } as any;
+    const mockModel = { findById: jest.fn().mockResolvedValue(post) } as any;
+    (postService as any).model = mockModel;
+
+    const result = await postService.likePost("p1", "u1");
+
+    expect(mockModel.findById).toHaveBeenCalledWith("p1");
+    expect(post.likes).toEqual([{ username: "u1" }]);
+    expect(save).toHaveBeenCalled();
+    expect(result).toEqual(post.likes);
+  });
+
+  it("throws when liking an already liked post", async () => {
+    const post = { likes: [{ username: "u1" }], save: jest.fn() } as any;
+    const mockModel = { findById: jest.fn().mockResolvedValue(post) } as any;
+    (postService as any).model = mockModel;
+
+    await expect(postService.likePost("p1", "u1")).rejects.toThrow(HttpError);
+  });
+
+  it("unlikes a liked post", async () => {
+    const save = jest.fn();
+    const post = { likes: [{ username: "u1" }], save } as any;
+    const mockModel = { findById: jest.fn().mockResolvedValue(post) } as any;
+    (postService as any).model = mockModel;
+
+    const result = await postService.unlikePost("p1", "u1");
+
+    expect(post.likes).toEqual([]);
+    expect(save).toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it("fails to remove someone else's comment", async () => {
+    const save = jest.fn();
+    const post = {
+      comments: [{ id: "c1", username: "u1" }],
+      save,
+    } as any;
+    const mockModel = { findById: jest.fn().mockResolvedValue(post) } as any;
+    (postService as any).model = mockModel;
+
+    await expect(
+      postService.removeComment("p1", "c1", "u2")
+    ).rejects.toThrow(HttpError);
+  });
+});

--- a/src/test/services/reviewService.test.ts
+++ b/src/test/services/reviewService.test.ts
@@ -1,0 +1,29 @@
+import { reviewService } from "../../services/ReviewService";
+import { Review } from "../../models/Review";
+import { HttpError } from "../../types/Errors";
+
+describe("ReviewService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a review", async () => {
+    (Review as any).create = jest.fn().mockResolvedValue({ id: "1" });
+    const result = await reviewService.addReview({ rating: 5 });
+    expect(Review.create).toHaveBeenCalledWith({ rating: 5 });
+    expect(result).toEqual({ id: "1" });
+  });
+
+  it("throws when review not found", async () => {
+    (Review as any).findById = jest.fn().mockResolvedValue(null);
+    await expect(reviewService.getReviewById("x"))
+      .rejects.toThrow(HttpError);
+  });
+
+  it("aggregates top rated reviews", async () => {
+    (Review as any).aggregate = jest.fn().mockResolvedValue([ { _id: "a" } ]);
+    const result = await reviewService.getTopRatedReviews("Doctor");
+    expect(Review.aggregate).toHaveBeenCalled();
+    expect(result).toEqual([{ _id: "a" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- increase coverage for PostService with like/unlike/comment cases
- cover ReviewService create, not found and aggregation flows

## Testing
- `npm run test:all --silent`

------
https://chatgpt.com/codex/tasks/task_e_684709bc46b4832a9d6a7fa8efd1e07d