### PR TITLE
Fix tests by mocking logger

### DIFF
--- a/src/test/controllers/businessControllers.test.ts
+++ b/src/test/controllers/businessControllers.test.ts
@@ -4,10 +4,16 @@ jest.mock("../../config/db");
 import app from "../../app";
 import { businessService } from "../../services/BusinessService";
 import geoService from "../../services/GeoService";
+import logger from "../../utils/logger";
 
 jest.mock("../../services/GeoService", () => ({
         __esModule: true,
         default: { geocodeAddress: jest.fn() },
+}));
+
+jest.mock("../../utils/logger", () => ({
+        __esModule: true,
+        default: { error: jest.fn() },
 }));
 
 jest.mock("../../middleware/authMiddleware", () => ({


### PR DESCRIPTION
## Summary
- silence error logs in business controller tests by mocking the logger

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_68485d8f3a60832a8d40f8eeeb25625a