### PR TITLE
Fix swagger route test timeout

### DIFF
--- a/src/test/swaggerRoute.test.ts
+++ b/src/test/swaggerRoute.test.ts
@@ -1,6 +1,9 @@
 import request from "supertest";
 jest.mock("../config/db");
 
+// Increase timeout because importing the app with ts-jest can be slow
+jest.setTimeout(10000);
+
 const originalEnv = process.env.NODE_ENV;
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
- raise timeout in swagger route tests so ts-jest import has time to load

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_68488c671ee4832a89e098f31235c4f6