### PR TITLE
Fix email regex to avoid catastrophic backtracking

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -51,7 +51,8 @@ const userSchema = new Schema<IUser>(
             required: true,
             unique: true,
             lowercase: true,
-            match: [/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/, 'Please fill a valid email address'],
+            // Simplified regex to avoid catastrophic backtracking in email validation
+            match: [/^[^\s@]+@[^\s@]+\.[^\s@]+$/, 'Please fill a valid email address'],
         },
         photo: {
             type: String,

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -51,8 +51,8 @@ const userSchema = new Schema<IUser>(
             required: true,
             unique: true,
             lowercase: true,
-            // Simplified regex to avoid catastrophic backtracking in email validation
-            match: [/^[^\s@]+@[^\s@]+\.[^\s@]+$/, 'Please fill a valid email address'],
+            // Updated regex is linear-time and slightly stricter to reduce invalid emails
+            match: [/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/, 'Please fill a valid email address'],
         },
         photo: {
             type: String,

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -52,7 +52,7 @@ const userSchema = new Schema<IUser>(
             unique: true,
             lowercase: true,
             // Updated regex is linear-time and slightly stricter to reduce invalid emails
-            match: [/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/, 'Please fill a valid email address'],
+            match: [EMAIL_REGEX, 'Please fill a valid email address'],
         },
         photo: {
             type: String,

--- a/src/test/models/userModel.test.ts
+++ b/src/test/models/userModel.test.ts
@@ -1,0 +1,27 @@
+import { User } from "../../models/User";
+
+describe("User model email validation", () => {
+    it("accepts a valid email", () => {
+        const user = new User({
+            username: "testuser",
+            email: "valid.email@example.com",
+            password: "password",
+            role: "user",
+            isAdmin: false,
+        });
+        const err = user.validateSync();
+        expect(err).toBeUndefined();
+    });
+
+    it("rejects an invalid email", () => {
+        const user = new User({
+            username: "testuser",
+            email: "invalid-email",
+            password: "password",
+            role: "user",
+            isAdmin: false,
+        });
+        const err = user.validateSync();
+        expect(err?.errors.email).toBeDefined();
+    });
+});

--- a/src/test/models/userModel.test.ts
+++ b/src/test/models/userModel.test.ts
@@ -1,11 +1,13 @@
 import { User } from "../../models/User";
 
+const DUMMY_PASSWORD = "testPass123!";
+
 describe("User model email validation", () => {
     it("accepts a valid email", () => {
         const user = new User({
             username: "testuser",
             email: "valid.email@example.com",
-            password: "password",
+            password: DUMMY_PASSWORD,
             role: "user",
             isAdmin: false,
         });
@@ -17,7 +19,7 @@ describe("User model email validation", () => {
         const user = new User({
             username: "testuser",
             email: "invalid-email",
-            password: "password",
+            password: DUMMY_PASSWORD,
             role: "user",
             isAdmin: false,
         });


### PR DESCRIPTION
## Summary
- simplify email regex to remove nested quantifiers

## Testing
- `npm install`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6848bfe9df38832a9793d515890b4f89