### PR TITLE
Add service and controller tests

### DIFF
--- a/src/test/controllers/controllerTestSetup.ts
+++ b/src/test/controllers/controllerTestSetup.ts
@@ -15,7 +15,7 @@ jest.mock("../../services/ReviewService", () => ({
 
 jest.mock("../../middleware/authMiddleware", () => ({
   protect: (req: any, _res: any, next: any) => {
-    req.user = { id: "user", role: "admin" };
+    req.user = { id: "user", _id: "user", role: "admin" };
     next();
   },
   admin: (_req: any, _res: any, next: any) => next(),

--- a/src/test/controllers/postControllers.test.ts
+++ b/src/test/controllers/postControllers.test.ts
@@ -1,0 +1,46 @@
+import request from "supertest";
+import app from "../../app";
+import { postService } from "../../services/PostService";
+
+jest.mock("../../config/db");
+jest.mock("../../services/PostService", () => ({
+  postService: {
+    getAll: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    updateById: jest.fn(),
+    deleteById: jest.fn(),
+    addComment: jest.fn(),
+    likePost: jest.fn(),
+    unlikePost: jest.fn(),
+  },
+}));
+
+jest.mock("../../middleware/authMiddleware", () => ({
+  protect: (req: any, _res: any, next: any) => {
+    req.user = { _id: "user", role: "admin" };
+    next();
+  },
+  admin: (_req: any, _res: any, next: any) => next(),
+  professional: (_req: any, _res: any, next: any) => next(),
+}));
+
+describe("Post Controllers", () => {
+  it("likes a post", async () => {
+    (postService.likePost as jest.Mock).mockResolvedValue([]);
+
+    const res = await request(app).post("/api/v1/posts/like/1");
+
+    expect(res.status).toBe(200);
+    expect(postService.likePost).toHaveBeenCalledWith("1", "user");
+  });
+
+  it("gets posts", async () => {
+    (postService.getAll as jest.Mock).mockResolvedValue([]);
+
+    const res = await request(app).get("/api/v1/posts");
+
+    expect(res.status).toBe(200);
+    expect(postService.getAll).toHaveBeenCalled();
+  });
+});

--- a/src/test/controllers/professionControllers.test.ts
+++ b/src/test/controllers/professionControllers.test.ts
@@ -1,0 +1,31 @@
+import request from "supertest";
+import { geoService } from "./controllerTestSetup";
+import app from "../../app";
+import { professionService } from "../../services/ProfessionService";
+import { reviewService } from "../../services/ReviewService";
+
+jest.mock("../../services/ProfessionService", () => ({
+  professionService: {
+    getAll: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    updateById: jest.fn(),
+    deleteById: jest.fn(),
+  },
+}));
+
+jest.mock("../../services/ReviewService", () => ({
+  reviewService: {
+    addReview: jest.fn(),
+    getTopRatedReviews: jest.fn(),
+  },
+}));
+
+describe("Profession Controllers", () => {
+  it("gets professions", async () => {
+    (professionService.getAll as jest.Mock).mockResolvedValue([]);
+    const res = await request(app).get("/api/v1/professions");
+    expect(res.status).toBe(200);
+    expect(professionService.getAll).toHaveBeenCalled();
+  });
+});

--- a/src/test/controllers/professionProfileController.test.ts
+++ b/src/test/controllers/professionProfileController.test.ts
@@ -1,0 +1,35 @@
+import request from "supertest";
+import app from "../../app";
+import { professionProfileService } from "../../services/ProfessionProfileService";
+
+jest.mock("../../services/ProfessionProfileService", () => ({
+  professionProfileService: {
+    getAll: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    updateById: jest.fn(),
+    deleteById: jest.fn(),
+  },
+}));
+
+jest.mock("../../middleware/authMiddleware", () => ({
+  protect: (_req: any, _res: any, next: any) => next(),
+  professional: (_req: any, _res: any, next: any) => next(),
+  admin: (_req: any, _res: any, next: any) => next(),
+}));
+
+describe("ProfessionProfile Controllers", () => {
+  it("lists profession profiles", async () => {
+    (professionProfileService.getAll as jest.Mock).mockResolvedValue([]);
+    const res = await request(app).get("/api/v1/professionalProfile");
+    expect(res.status).toBe(200);
+    expect(professionProfileService.getAll).toHaveBeenCalled();
+  });
+
+  it("deletes a profession profile", async () => {
+    (professionProfileService.deleteById as jest.Mock).mockResolvedValue(undefined);
+    const res = await request(app).delete("/api/v1/professionalProfile/1");
+    expect(res.status).toBe(200);
+    expect(professionProfileService.deleteById).toHaveBeenCalledWith("1");
+  });
+});

--- a/src/test/controllers/recipesControllers.test.ts
+++ b/src/test/controllers/recipesControllers.test.ts
@@ -1,0 +1,31 @@
+import request from "supertest";
+import { geoService } from "./controllerTestSetup";
+import app from "../../app";
+import { recipeService } from "../../services/RecipesService";
+import { reviewService } from "../../services/ReviewService";
+
+jest.mock("../../services/RecipesService", () => ({
+  recipeService: {
+    getAll: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    updateById: jest.fn(),
+    deleteById: jest.fn(),
+  },
+}));
+
+jest.mock("../../services/ReviewService", () => ({
+  reviewService: {
+    addReview: jest.fn(),
+    getTopRatedReviews: jest.fn(),
+  },
+}));
+
+describe("Recipes Controllers", () => {
+  it("lists recipes", async () => {
+    (recipeService.getAll as jest.Mock).mockResolvedValue([]);
+    const res = await request(app).get("/api/v1/recipes");
+    expect(res.status).toBe(200);
+    expect(recipeService.getAll).toHaveBeenCalled();
+  });
+});

--- a/src/test/controllers/sanctuaryControllers.test.ts
+++ b/src/test/controllers/sanctuaryControllers.test.ts
@@ -1,0 +1,40 @@
+import request from "supertest";
+import { geoService } from "./controllerTestSetup";
+import app from "../../app";
+import { sanctuaryService } from "../../services/SanctuaryService";
+import { reviewService } from "../../services/ReviewService";
+
+jest.mock("../../services/SanctuaryService", () => ({
+  sanctuaryService: {
+    getAll: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    updateById: jest.fn(),
+    deleteById: jest.fn(),
+  },
+}));
+
+describe("Sanctuary Controllers", () => {
+  it("creates a sanctuary with geocode", async () => {
+    (geoService.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 1, lng: 2 });
+    (sanctuaryService.create as jest.Mock).mockResolvedValue({ id: "1" });
+
+    await request(app)
+      .post("/api/v1/sanctuaries")
+      .send({ address: "a" });
+
+    expect(geoService.geocodeAddress).toHaveBeenCalledWith("a");
+    expect(sanctuaryService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ address: "a", location: { type: "Point", coordinates: [2, 1] } })
+    );
+  });
+
+  it("adds a review", async () => {
+    (reviewService.addReview as jest.Mock).mockResolvedValue({ id: "r" });
+    const res = await request(app)
+      .post("/api/v1/sanctuaries/add-review/1")
+      .send({ text: "good" });
+    expect(res.status).toBe(200);
+    expect(reviewService.addReview).toHaveBeenCalledWith({ text: "good", sanctuaryId: "1" });
+  });
+});

--- a/src/test/services/doctorService.test.ts
+++ b/src/test/services/doctorService.test.ts
@@ -1,0 +1,10 @@
+import { doctorService } from "../../services/DoctorService";
+
+describe("DoctorService", () => {
+  it("delegates getAll to the model", async () => {
+    const mockModel = { find: jest.fn().mockResolvedValue([]) } as any;
+    (doctorService as any).model = mockModel;
+    await doctorService.getAll();
+    expect(mockModel.find).toHaveBeenCalled();
+  });
+});

--- a/src/test/services/marketsService.test.ts
+++ b/src/test/services/marketsService.test.ts
@@ -1,0 +1,10 @@
+import { marketsService } from "../../services/MarketsService";
+
+describe("MarketsService", () => {
+  it("delegates getAll to the model", async () => {
+    const mockModel = { find: jest.fn().mockResolvedValue([]) } as any;
+    (marketsService as any).model = mockModel;
+    await marketsService.getAll();
+    expect(mockModel.find).toHaveBeenCalled();
+  });
+});

--- a/src/test/services/professionProfileService.test.ts
+++ b/src/test/services/professionProfileService.test.ts
@@ -1,0 +1,10 @@
+import { professionProfileService } from "../../services/ProfessionProfileService";
+
+describe("ProfessionProfileService", () => {
+  it("delegates getAll to the model", async () => {
+    const mockModel = { find: jest.fn().mockResolvedValue([]) } as any;
+    (professionProfileService as any).model = mockModel;
+    await professionProfileService.getAll();
+    expect(mockModel.find).toHaveBeenCalled();
+  });
+});

--- a/src/test/services/professionService.test.ts
+++ b/src/test/services/professionService.test.ts
@@ -1,0 +1,10 @@
+import { professionService } from "../../services/ProfessionService";
+
+describe("ProfessionService", () => {
+  it("delegates getAll to the model", async () => {
+    const mockModel = { find: jest.fn().mockResolvedValue([]) } as any;
+    (professionService as any).model = mockModel;
+    await professionService.getAll();
+    expect(mockModel.find).toHaveBeenCalled();
+  });
+});

--- a/src/test/services/sanctuaryService.test.ts
+++ b/src/test/services/sanctuaryService.test.ts
@@ -1,0 +1,10 @@
+import { sanctuaryService } from "../../services/SanctuaryService";
+
+describe("SanctuaryService", () => {
+  it("delegates getAll to the model", async () => {
+    const mockModel = { find: jest.fn().mockResolvedValue([]) } as any;
+    (sanctuaryService as any).model = mockModel;
+    await sanctuaryService.getAll();
+    expect(mockModel.find).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- augment auth mock to include `_id`
- add controller tests for posts, profession profiles, professions, recipes, and sanctuaries
- add simple service tests for several services

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6848bf548260832aad964157fa2858c5