### PR TITLE
Fix EMAIL_REGEX reference causing tests to fail

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,6 +1,12 @@
 import bcrypt from 'bcryptjs';
 import mongoose, { Schema, Document } from 'mongoose';
 
+/**
+ * Email regex that avoids catastrophic backtracking.
+ * Exported for reuse across the code base.
+ */
+export const EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+
 export interface IUser extends Document {
     _id: string;
     username: string;


### PR DESCRIPTION
## Summary
- export a reusable `EMAIL_REGEX` constant in `User` model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c7ad2e98832a9739473921eb8c0a