### PR TITLE
Fix hard-coded password in userModel test

### DIFF
--- a/src/test/models/userModel.test.ts
+++ b/src/test/models/userModel.test.ts
@@ -1,6 +1,8 @@
 import { User } from "../../models/User";
+import { faker } from "@faker-js/faker";
 
-const DUMMY_PASSWORD = "testPass123!";
+// Generate a throwaway password for testing instead of using a hard-coded one
+const DUMMY_PASSWORD = faker.internet.password(12);
 
 describe("User model email validation", () => {
     it("accepts a valid email", () => {


### PR DESCRIPTION
## Summary
- remove hard-coded password string in tests
- use faker to generate a temporary password for user model tests

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848ca6b3164832ab7863990d3fad8fb