### PR TITLE
test: remove any from unit tests

### DIFF
--- a/src/test/services/businessService.test.ts
+++ b/src/test/services/businessService.test.ts
@@ -4,22 +4,38 @@
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
+// Define minimal Business interfaces for type safety
+interface Business {
+    _id: string;
+    namePlace: string;
+}
+
+interface BusinessModel {
+    create: (data: Partial<Business>) => Business;
+    find: () => Business[];
+    findById: (id: string) => Business | null;
+    findByIdAndUpdate: (id: string, data: Partial<Business>) => Business | null;
+    deleteOne: (filter: unknown) => unknown;
+    modelName: string;
+    exec: () => unknown;
+}
+
 // Mock Business model
-const mockBusiness = {
-    create: vi.fn(),
-    find: vi.fn(),
-    findById: vi.fn(),
-    findByIdAndUpdate: vi.fn(),
-    deleteOne: vi.fn(),
+const mockBusiness: BusinessModel = {
+    create: vi.fn<(data: Partial<Business>) => Business>(),
+    find: vi.fn<() => Business[]>(),
+    findById: vi.fn<(id: string) => Business | null>(),
+    findByIdAndUpdate: vi.fn<(id: string, data: Partial<Business>) => Business | null>(),
+    deleteOne: vi.fn<(filter: unknown) => unknown>(),
     modelName: 'Business',
-    exec: vi.fn(),
+    exec: vi.fn<() => unknown>(),
 };
 
 // Mock BaseService
 vi.mock('../../services/BaseService', () => ({
     default: class MockBaseService {
-        protected model: any;
-        constructor(model: any) {
+        protected model: BusinessModel;
+        constructor(model: BusinessModel) {
             this.model = model;
         }
 
@@ -31,7 +47,7 @@ vi.mock('../../services/BaseService', () => ({
             return this.model.findById(id);
         }
 
-        async create(data: any) {
+        async create(data: Partial<Business>) {
             return this.model.create(data);
         }
     },
@@ -57,7 +73,7 @@ describe('BusinessService', () => {
             namePlace: `Test Business ${id}`,
         }));
 
-        mockBusiness.create.mockImplementation((data: any) => ({
+        mockBusiness.create.mockImplementation((data: Partial<Business>) => ({
             _id: '3',
             ...data,
         }));

--- a/src/test/services/cacheService.test.ts
+++ b/src/test/services/cacheService.test.ts
@@ -5,13 +5,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setupTest } from '../config/unified-test-config';
 import { mockFactory } from '../mocks/unified-mock-factory';
+import type { CacheService as CacheServiceType } from '../../services/CacheService';
 
 // Mock the CacheService module
 vi.mock('../../services/CacheService', () => mockFactory.createCacheServiceMockModule());
 
 describe('CacheService', () => {
     const testHooks = setupTest();
-    let cacheService: any;
+    let cacheService: CacheServiceType;
 
     beforeEach(async () => {
         await testHooks.beforeEach();

--- a/src/test/services/postService.test.ts
+++ b/src/test/services/postService.test.ts
@@ -8,8 +8,22 @@ import { HttpError } from '../../types/Errors';
 const existingUserId = faker.database.mongodbObjectId();
 const existingCommentUserId = faker.database.mongodbObjectId();
 
+// Define minimal types for likes and comments to avoid `any` usage
+interface Like {
+    username: Types.ObjectId;
+}
+
+interface Comment {
+    id: string;
+    username: Types.ObjectId;
+}
+
 // Create a proper mock post with array methods
-const createMockPost = (id: string, likes: any[] = [], comments: any[] = []) => {
+const createMockPost = (
+    id: string,
+    likes: Like[] = [],
+    comments: Comment[] = []
+) => {
     const post = {
         _id: id,
         likes: [...likes],


### PR DESCRIPTION
## Summary
- replace `any` with typed interfaces and mocks in PostService tests
- add typed Business and BusinessModel interfaces in BusinessService tests
- use CacheService type for cache tests

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_688d0e8f6940832ab925ea013de6847a