### PR TITLE
fix(users): soft delete + block reuse in auth flows (BE-03)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -55,6 +55,8 @@ abstract class BaseService {
 
     protected async validateUserNotExists(email: string) {
         const sanitizedEmail = validateAndSanitizeEmail(email);
+        // Intentionally NOT filtering by isDeleted: a soft-deleted account still
+        // owns the email address and must not be reused for a new registration.
         const existingUser = await User.findOne({ email: sanitizedEmail }).exec();
         if (existingUser) {
             throw new HttpError(HttpStatusCode.BAD_REQUEST, getErrorMessage('User already exists'));
@@ -63,7 +65,11 @@ abstract class BaseService {
 
     protected async getUserByEmail(email: string) {
         const sanitizedEmail = validateAndSanitizeEmail(email);
-        const user = await User.findOne({ email: sanitizedEmail }).select('+password').exec();
+        // Soft-deleted accounts MUST NOT be resolvable via email lookups used by
+        // authentication flows (BE-03 follow-up: prevent login/reset reuse).
+        const user = await User.findOne({ email: sanitizedEmail, isDeleted: false })
+            .select('+password')
+            .exec();
         this.validateUserExists(user);
         return user!;
     }
@@ -116,7 +122,11 @@ abstract class BaseService {
             throw new HttpError(HttpStatusCode.BAD_REQUEST, getErrorMessage('Invalid reset token'));
         }
 
-        const user = await User.findById(decoded.userId).exec();
+        // Soft-deleted accounts must not be able to consume an otherwise-valid
+        // reset token (BE-03 follow-up).
+        const user = await User.findOne({ _id: decoded.userId, isDeleted: false })
+            .select('+password')
+            .exec();
         this.validateUserExists(user);
         return user!;
     }
@@ -143,7 +153,12 @@ class UserService extends BaseService {
 
     async loginUser(email: string, password: string) {
         const sanitizedEmail = validateAndSanitizeEmail(email);
-        const user = await User.findOne({ email: sanitizedEmail }).select('+password').exec();
+        // BE-03 follow-up: soft-deleted users must not be able to authenticate.
+        // The isDeleted:false filter ensures we return the same "Invalid credentials"
+        // error as a non-existent account (no account enumeration).
+        const user = await User.findOne({ email: sanitizedEmail, isDeleted: false })
+            .select('+password')
+            .exec();
         await this.validateUserCredentials(user, password);
         const tokens = await TokenService.generateTokens(user!._id.toString(), user!.email, user!.role);
         const userResponse = this.getUserResponse(user!);
@@ -172,7 +187,10 @@ class UserService extends BaseService {
 
         try {
             const sanitizedEmail = validateAndSanitizeEmail(email);
-            const user = await User.findOne({ email: sanitizedEmail }).select('+password').exec();
+            // BE-03 follow-up: soft-deleted users must not trigger reset emails.
+            const user = await User.findOne({ email: sanitizedEmail, isDeleted: false })
+                .select('+password')
+                .exec();
 
             if (user) {
                 const resetToken = await this.generateResetToken(user);
@@ -267,6 +285,18 @@ class UserService extends BaseService {
         ).exec();
         if (!updated) {
             throw new HttpError(HttpStatusCode.NOT_FOUND, 'User not found');
+        }
+        // BE-03 follow-up: revoke all outstanding access/refresh tokens so that
+        // any session opened before the soft delete is immediately invalidated.
+        // Token revocation failures must not mask a successful soft delete, but
+        // they must be surfaced in logs so ops can detect replay risk.
+        try {
+            await TokenService.revokeAllUserTokens(userId);
+        } catch (error) {
+            logger.error('deleteUserById: failed to revoke tokens for soft-deleted user', {
+                userId,
+                error,
+            });
         }
         return { message: 'User deleted successfully' };
     }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -208,7 +208,7 @@ class UserService extends BaseService {
         const { page, limit, search, sortBy } = params;
         const skip = (page - 1) * limit;
 
-        const filter: Record<string, unknown> = {};
+        const filter: Record<string, unknown> = { isDeleted: false };
         if (search) {
             const escaped = escapeRegex(search);
             filter.$or = [
@@ -246,7 +246,7 @@ class UserService extends BaseService {
 
     async findUserById(userId: string) {
         if (!userId) throw new UserIdRequiredError('User ID not found');
-        const user = await User.findById(userId).exec();
+        const user = await User.findOne({ _id: userId, isDeleted: false }).exec();
         return user;
     }
 
@@ -260,8 +260,12 @@ class UserService extends BaseService {
     }
 
     async deleteUserById(userId: string) {
-        const deleted = await User.findByIdAndDelete(userId).exec();
-        if (!deleted) {
+        const updated = await User.findOneAndUpdate(
+            { _id: userId, isDeleted: false },
+            { isDeleted: true, isActive: false },
+            { new: true }
+        ).exec();
+        if (!updated) {
             throw new HttpError(HttpStatusCode.NOT_FOUND, 'User not found');
         }
         return { message: 'User deleted successfully' };

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -67,9 +67,7 @@ abstract class BaseService {
         const sanitizedEmail = validateAndSanitizeEmail(email);
         // Soft-deleted accounts MUST NOT be resolvable via email lookups used by
         // authentication flows (BE-03 follow-up: prevent login/reset reuse).
-        const user = await User.findOne({ email: sanitizedEmail, isDeleted: false })
-            .select('+password')
-            .exec();
+        const user = await User.findOne({ email: sanitizedEmail, isDeleted: false }).select('+password').exec();
         this.validateUserExists(user);
         return user!;
     }
@@ -124,9 +122,7 @@ abstract class BaseService {
 
         // Soft-deleted accounts must not be able to consume an otherwise-valid
         // reset token (BE-03 follow-up).
-        const user = await User.findOne({ _id: decoded.userId, isDeleted: false })
-            .select('+password')
-            .exec();
+        const user = await User.findOne({ _id: decoded.userId, isDeleted: false }).select('+password').exec();
         this.validateUserExists(user);
         return user!;
     }
@@ -156,9 +152,7 @@ class UserService extends BaseService {
         // BE-03 follow-up: soft-deleted users must not be able to authenticate.
         // The isDeleted:false filter ensures we return the same "Invalid credentials"
         // error as a non-existent account (no account enumeration).
-        const user = await User.findOne({ email: sanitizedEmail, isDeleted: false })
-            .select('+password')
-            .exec();
+        const user = await User.findOne({ email: sanitizedEmail, isDeleted: false }).select('+password').exec();
         await this.validateUserCredentials(user, password);
         const tokens = await TokenService.generateTokens(user!._id.toString(), user!.email, user!.role);
         const userResponse = this.getUserResponse(user!);
@@ -188,9 +182,7 @@ class UserService extends BaseService {
         try {
             const sanitizedEmail = validateAndSanitizeEmail(email);
             // BE-03 follow-up: soft-deleted users must not trigger reset emails.
-            const user = await User.findOne({ email: sanitizedEmail, isDeleted: false })
-                .select('+password')
-                .exec();
+            const user = await User.findOne({ email: sanitizedEmail, isDeleted: false }).select('+password').exec();
 
             if (user) {
                 const resetToken = await this.generateResetToken(user);

--- a/src/test/services/userService.test.ts
+++ b/src/test/services/userService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { HttpStatusCode } from '../../types/Errors.js';
 
 // ---------------------------------------------------------------------------
@@ -27,6 +27,14 @@ vi.mock('../../services/TokenService.js', () => ({
         generateTokens: vi.fn().mockResolvedValue({ accessToken: 'at', refreshToken: 'rt' }),
         verifyAccessToken: vi.fn(),
         isUserTokensRevoked: vi.fn().mockResolvedValue(false),
+        revokeAllUserTokens: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+
+vi.mock('jsonwebtoken', () => ({
+    default: {
+        sign: vi.fn().mockReturnValue('signed-token'),
+        verify: vi.fn(),
     },
 }));
 
@@ -40,6 +48,8 @@ vi.mock('../../utils/logger.js', () => ({
 
 // Import AFTER all mocks are registered
 import UserService from '../../services/UserService.js';
+import TokenService from '../../services/TokenService.js';
+import jwt from 'jsonwebtoken';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -153,6 +163,168 @@ describe('UserService — soft delete (BE-03)', () => {
         it('throws UserIdRequiredError when userId is empty string', async () => {
             await expect(UserService.findUserById('')).rejects.toThrow();
             expect(mockFindOne).not.toHaveBeenCalled();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // loginUser — BE-03 follow-up: soft-deleted users must not authenticate
+    // -----------------------------------------------------------------------
+    describe('loginUser (soft-delete regression)', () => {
+        function selectChain(resolvedValue: unknown) {
+            return {
+                select: vi.fn().mockReturnValue({
+                    exec: vi.fn().mockResolvedValue(resolvedValue),
+                }),
+            };
+        }
+
+        it('filters by isDeleted=false so soft-deleted users cannot log in', async () => {
+            // User.findOne must be called with isDeleted: false. Simulate a
+            // soft-deleted user by returning null (the filter excluded them).
+            mockFindOne.mockReturnValue(selectChain(null));
+
+            await expect(UserService.loginUser('ghost@example.com', 'secret123')).rejects.toMatchObject({
+                statusCode: HttpStatusCode.UNAUTHORIZED,
+            });
+
+            expect(mockFindOne).toHaveBeenCalledWith({
+                email: 'ghost@example.com',
+                isDeleted: false,
+            });
+            expect(TokenService.generateTokens).not.toHaveBeenCalled();
+        });
+
+        it('returns Invalid credentials (not 404) to avoid account enumeration', async () => {
+            mockFindOne.mockReturnValue(selectChain(null));
+
+            await expect(UserService.loginUser('ghost@example.com', 'secret123')).rejects.toMatchObject({
+                statusCode: HttpStatusCode.UNAUTHORIZED,
+            });
+        });
+
+        it('issues tokens only when findOne returns an active user', async () => {
+            const fakeUser = {
+                _id: { toString: () => 'user-1' },
+                email: 'alice@example.com',
+                role: 'user',
+                username: 'alice',
+                photo: null,
+                matchPassword: vi.fn().mockResolvedValue(true),
+            };
+            mockFindOne.mockReturnValue(selectChain(fakeUser));
+
+            const result = await UserService.loginUser('alice@example.com', 'secret123');
+
+            expect(result.token).toBe('at');
+            expect(TokenService.generateTokens).toHaveBeenCalledWith('user-1', 'alice@example.com', 'user');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // forgotPassword — BE-03 follow-up
+    // -----------------------------------------------------------------------
+    describe('forgotPassword (soft-delete regression)', () => {
+        function selectChain(resolvedValue: unknown) {
+            return {
+                select: vi.fn().mockReturnValue({
+                    exec: vi.fn().mockResolvedValue(resolvedValue),
+                }),
+            };
+        }
+
+        it('does not send a reset email when the user is soft-deleted', async () => {
+            mockFindOne.mockReturnValue(selectChain(null));
+            const nodemailer = (await import('nodemailer')).default as unknown as {
+                createTransport: ReturnType<typeof vi.fn>;
+            };
+            const sendMail = vi.fn().mockResolvedValue(undefined);
+            nodemailer.createTransport.mockReturnValue({ sendMail });
+
+            const result = await UserService.forgotPassword('ghost@example.com');
+
+            expect(mockFindOne).toHaveBeenCalledWith({
+                email: 'ghost@example.com',
+                isDeleted: false,
+            });
+            expect(sendMail).not.toHaveBeenCalled();
+            // Always returns the safe generic response (OWASP A07).
+            expect(result).toEqual({
+                message: 'If that email exists, reset instructions have been sent',
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // resetPassword — BE-03 follow-up
+    // -----------------------------------------------------------------------
+    describe('resetPassword (soft-delete regression)', () => {
+        const originalSecret = process.env.JWT_RESET_SECRET;
+
+        beforeEach(() => {
+            process.env.JWT_RESET_SECRET = 'test-reset-secret';
+        });
+
+        afterAll(() => {
+            process.env.JWT_RESET_SECRET = originalSecret;
+        });
+
+        it('rejects a valid reset token if the target user has been soft-deleted', async () => {
+            (jwt.verify as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+                userId: 'deleted-user',
+                purpose: 'password-reset',
+            });
+
+            // getUserByResetToken uses findOne({_id, isDeleted:false}).select(...).exec()
+            mockFindOne.mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                    exec: vi.fn().mockResolvedValue(null),
+                }),
+            });
+
+            await expect(UserService.resetPassword('valid.jwt.token', 'newPass123!')).rejects.toMatchObject({
+                statusCode: HttpStatusCode.NOT_FOUND,
+            });
+
+            expect(mockFindOne).toHaveBeenCalledWith({
+                _id: 'deleted-user',
+                isDeleted: false,
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // deleteUserById — BE-03 follow-up: must revoke active tokens
+    // -----------------------------------------------------------------------
+    describe('deleteUserById token revocation (BE-03 follow-up)', () => {
+        it('revokes all user tokens after a successful soft delete', async () => {
+            const fakeUser = { _id: 'user-revoke', isDeleted: true, isActive: false };
+            mockFindOneAndUpdate.mockReturnValue(chainableMock(fakeUser));
+
+            await UserService.deleteUserById('user-revoke');
+
+            expect(TokenService.revokeAllUserTokens).toHaveBeenCalledWith('user-revoke');
+        });
+
+        it('does not call revokeAllUserTokens when the soft delete fails (user not found)', async () => {
+            mockFindOneAndUpdate.mockReturnValue(chainableMock(null));
+
+            await expect(UserService.deleteUserById('nonexistent')).rejects.toMatchObject({
+                statusCode: HttpStatusCode.NOT_FOUND,
+            });
+            expect(TokenService.revokeAllUserTokens).not.toHaveBeenCalled();
+        });
+
+        it('still returns success when token revocation fails (logs the error)', async () => {
+            const fakeUser = { _id: 'user-revoke-fail', isDeleted: true };
+            mockFindOneAndUpdate.mockReturnValue(chainableMock(fakeUser));
+            (TokenService.revokeAllUserTokens as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+                new Error('redis down')
+            );
+
+            const result = await UserService.deleteUserById('user-revoke-fail');
+
+            expect(result).toEqual({ message: 'User deleted successfully' });
+            expect(TokenService.revokeAllUserTokens).toHaveBeenCalledWith('user-revoke-fail');
         });
     });
 });

--- a/src/test/services/userService.test.ts
+++ b/src/test/services/userService.test.ts
@@ -1,41 +1,158 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { HttpStatusCode } from '../../types/Errors.js';
 
-// Mock the service
-vi.mock('../../services/UserService', () => ({
-    default: vi.fn().mockImplementation(() => ({
-        createUser: vi.fn(),
-        getUserById: vi.fn(),
-        updateUser: vi.fn(),
-        deleteUser: vi.fn(),
-    })),
+// ---------------------------------------------------------------------------
+// vi.hoisted ensures these are available when the vi.mock factories run
+// (vi.mock calls are hoisted to the top of the file by vitest's transformer)
+// ---------------------------------------------------------------------------
+const { mockFindOneAndUpdate, mockFindOne, mockFind, mockCountDocuments } = vi.hoisted(() => ({
+    mockFindOneAndUpdate: vi.fn(),
+    mockFindOne: vi.fn(),
+    mockFind: vi.fn(),
+    mockCountDocuments: vi.fn(),
 }));
 
-describe('User Service Tests', () => {
+vi.mock('../../models/User.js', () => ({
+    User: {
+        findOneAndUpdate: mockFindOneAndUpdate,
+        findOne: mockFindOne,
+        find: mockFind,
+        countDocuments: mockCountDocuments,
+        create: vi.fn(),
+    },
+}));
+
+vi.mock('../../services/TokenService.js', () => ({
+    default: {
+        generateTokens: vi.fn().mockResolvedValue({ accessToken: 'at', refreshToken: 'rt' }),
+        verifyAccessToken: vi.fn(),
+        isUserTokensRevoked: vi.fn().mockResolvedValue(false),
+    },
+}));
+
+vi.mock('nodemailer', () => ({
+    default: { createTransport: vi.fn().mockReturnValue({ sendMail: vi.fn() }) },
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+    default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// Import AFTER all mocks are registered
+import UserService from '../../services/UserService.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function chainableMock(resolvedValue: unknown) {
+    return { exec: vi.fn().mockResolvedValue(resolvedValue) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('UserService — soft delete (BE-03)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
-    it('should have user service available', () => {
-        expect(true).toBe(true);
+    // -----------------------------------------------------------------------
+    // deleteUserById
+    // -----------------------------------------------------------------------
+    describe('deleteUserById', () => {
+        it('sets isDeleted=true and isActive=false instead of hard-deleting the document', async () => {
+            const fakeUser = { _id: 'user-123', isDeleted: true, isActive: false };
+            mockFindOneAndUpdate.mockReturnValue(chainableMock(fakeUser));
+
+            const result = await UserService.deleteUserById('user-123');
+
+            expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+                { _id: 'user-123', isDeleted: false },
+                { isDeleted: true, isActive: false },
+                { new: true }
+            );
+            expect(result).toEqual({ message: 'User deleted successfully' });
+        });
+
+        it('throws NOT_FOUND when no active user matches the id', async () => {
+            mockFindOneAndUpdate.mockReturnValue(chainableMock(null));
+
+            await expect(UserService.deleteUserById('nonexistent')).rejects.toMatchObject({
+                statusCode: HttpStatusCode.NOT_FOUND,
+            });
+        });
+
+        it('throws NOT_FOUND when the user is already soft-deleted', async () => {
+            // The { isDeleted: false } filter means already-deleted users return null
+            mockFindOneAndUpdate.mockReturnValue(chainableMock(null));
+
+            await expect(UserService.deleteUserById('already-deleted')).rejects.toMatchObject({
+                statusCode: HttpStatusCode.NOT_FOUND,
+            });
+        });
     });
 
-    it('should handle basic functionality', () => {
-        const mockService = {
-            createUser: vi.fn(),
-            getUserById: vi.fn(),
-            updateUser: vi.fn(),
-            deleteUser: vi.fn(),
-        };
+    // -----------------------------------------------------------------------
+    // findAllUsers
+    // -----------------------------------------------------------------------
+    describe('findAllUsers', () => {
+        it('always includes isDeleted=false in the filter to exclude soft-deleted users', async () => {
+            mockCountDocuments.mockResolvedValue(0);
+            mockFind.mockReturnValue({
+                sort: vi.fn().mockReturnThis(),
+                skip: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                exec: vi.fn().mockResolvedValue([]),
+            });
 
-        expect(typeof mockService.createUser).toBe('function');
-        expect(typeof mockService.getUserById).toBe('function');
-        expect(typeof mockService.updateUser).toBe('function');
-        expect(typeof mockService.deleteUser).toBe('function');
+            await UserService.findAllUsers({ page: 1, limit: 10 });
+
+            const filterArg = mockCountDocuments.mock.calls[0][0] as Record<string, unknown>;
+            expect(filterArg).toMatchObject({ isDeleted: false });
+        });
+
+        it('merges isDeleted=false with search $or filter when search is provided', async () => {
+            mockCountDocuments.mockResolvedValue(0);
+            mockFind.mockReturnValue({
+                sort: vi.fn().mockReturnThis(),
+                skip: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockReturnThis(),
+                exec: vi.fn().mockResolvedValue([]),
+            });
+
+            await UserService.findAllUsers({ page: 1, limit: 10, search: 'alice' });
+
+            const filterArg = mockCountDocuments.mock.calls[0][0] as Record<string, unknown>;
+            expect(filterArg).toMatchObject({ isDeleted: false });
+            expect(filterArg).toHaveProperty('$or');
+        });
     });
 
-    it('should handle basic operations', () => {
-        const arr = [1, 2, 3];
-        expect(arr.length).toBe(3);
-        expect(arr[0]).toBe(1);
+    // -----------------------------------------------------------------------
+    // findUserById
+    // -----------------------------------------------------------------------
+    describe('findUserById', () => {
+        it('queries with isDeleted=false to exclude soft-deleted users', async () => {
+            const fakeUser = { _id: 'user-abc', isDeleted: false };
+            mockFindOne.mockReturnValue(chainableMock(fakeUser));
+
+            const result = await UserService.findUserById('user-abc');
+
+            expect(mockFindOne).toHaveBeenCalledWith({ _id: 'user-abc', isDeleted: false });
+            expect(result).toEqual(fakeUser);
+        });
+
+        it('returns null when the user is soft-deleted (findOne returns null)', async () => {
+            mockFindOne.mockReturnValue(chainableMock(null));
+
+            const result = await UserService.findUserById('deleted-user');
+
+            expect(result).toBeNull();
+        });
+
+        it('throws UserIdRequiredError when userId is empty string', async () => {
+            await expect(UserService.findUserById('')).rejects.toThrow();
+            expect(mockFindOne).not.toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Replace hard delete with soft delete (`isDeleted: true, isActive: false`) in `UserService.deleteUserById`
- Filter `isDeleted: false` in `findAllUsers`, `findUserById`, `getUserByEmail`, `getUserByResetToken`
- Block soft-deleted users from login, password reset request, and token consumption
- Revoke all active tokens when a user is soft-deleted
- `validateUserNotExists` intentionally still matches soft-deleted users (prevents email reuse / impersonation)

## Audit reference
BE-03 (Critical) — Hard delete corrupts author references in reviews/posts/businesses. Follow-up addresses reviewer blocker: `loginUser` returning tokens for soft-deleted accounts (OWASP A07).

## Test plan
- [x] 16/16 unit tests pass in userService.test.ts (8 original + 8 regression)
- [x] Login regression: soft-deleted user gets 401, no tokens issued
- [x] forgotPassword: no email sent for soft-deleted user
- [x] resetPassword: valid token rejected if user soft-deleted
- [x] deleteUserById: TokenService.revokeAllUserTokens called
- [x] tsc --noEmit clean
- [ ] Integration test in staging before merge