### PR TITLE
fix(business): align Joi validator with Mongoose model (S1-03)

### DIFF
--- a/src/routes/businessRoutes.ts
+++ b/src/routes/businessRoutes.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import { protect, admin } from '../middleware/authMiddleware.js';
 import { browserCacheValidation, businessCacheMiddleware } from '../middleware/cache.js';
 import { validate, rateLimits, validateInputLength, validateObjectId } from '../middleware/validation.js';
-import { paramSchemas, reviewSchemas } from '../utils/validators.js';
+import { paramSchemas, reviewSchemas, businessSchemas } from '../utils/validators.js';
 import {
     getBusinesses,
     getBusinessById,
@@ -25,7 +25,7 @@ router.get('/search', searchBusinesses);
 
 router.get('/', businessCacheMiddleware(), getBusinesses);
 router.get('/:id', validateObjectId(), businessCacheMiddleware(), getBusinessById);
-router.post('/', protect, createBusiness);
+router.post('/', protect, validateInputLength(2048), validate({ body: businessSchemas.create }), createBusiness);
 
 // Standardized review routes (new OpenAPI 3.0 compliant paths)
 router.post(
@@ -53,7 +53,7 @@ router.post(
     addReviewToBusiness
 );
 
-router.put('/:id', protect, admin, validateObjectId(), updateBusiness);
+router.put('/:id', protect, admin, validateObjectId(), validateInputLength(2048), validate({ body: businessSchemas.update }), updateBusiness);
 router.delete('/:id', protect, admin, validateObjectId(), deleteBusiness);
 
 export default router;

--- a/src/routes/businessRoutes.ts
+++ b/src/routes/businessRoutes.ts
@@ -53,7 +53,15 @@ router.post(
     addReviewToBusiness
 );
 
-router.put('/:id', protect, admin, validateObjectId(), validateInputLength(2048), validate({ body: businessSchemas.update }), updateBusiness);
+router.put(
+    '/:id',
+    protect,
+    admin,
+    validateObjectId(),
+    validateInputLength(2048),
+    validate({ body: businessSchemas.update }),
+    updateBusiness
+);
 router.delete('/:id', protect, admin, validateObjectId(), deleteBusiness);
 
 export default router;

--- a/src/test/middleware/validation.test.ts
+++ b/src/test/middleware/validation.test.ts
@@ -714,9 +714,9 @@ describe('timePattern validator — commonSchemas.time', () => {
 });
 
 // ---------------------------------------------------------------------------
-// timePattern integration — businessSchemas.create openingHours end-to-end
+// timePattern integration — businessSchemas.create hours end-to-end
 // Exercises the full schema that composes commonSchemas.time inside
-// createOpeningHoursSchema(), validating the real request path.
+// the business hours validator, validating the real request path.
 // ---------------------------------------------------------------------------
 
 const businessApp = express();
@@ -729,34 +729,33 @@ businessApp.post('/test-business-create', validate({ body: businessSchemas.creat
 );
 
 const validBusinessPayload = () => ({
-    name: 'Green Bites',
+    namePlace: 'Green Bites',
     address: '123 Vegan St',
-    phoneNumber: '+1 555 123 4567',
-    category: 'cafe',
+    typeBusiness: 'cafe',
     location: { type: 'Point', coordinates: [-73.9857, 40.7484] },
 });
 
-describe('timePattern integration — businessSchemas.create openingHours', () => {
-    it('accepts a valid openingHours block with correct HH:MM times', async () => {
+describe('timePattern integration — businessSchemas.create hours', () => {
+    it('accepts a valid hours block with correct HH:MM times', async () => {
         const payload = {
             ...validBusinessPayload(),
-            openingHours: {
-                monday: { open: '09:00', close: '21:30' },
-                friday: { open: '08:00', close: '23:59' },
-            },
+            hours: [
+                { dayOfWeek: 'monday', openTime: '09:00', closeTime: '21:30' },
+                { dayOfWeek: 'friday', openTime: '08:00', closeTime: '23:59' },
+            ],
         };
 
         const response = await request(businessApp).post('/test-business-create').send(payload);
 
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
-        expect(response.body.data.openingHours.monday.open).toBe('09:00');
+        expect(response.body.data.hours[0].openTime).toBe('09:00');
     });
 
-    it('rejects openingHours with an invalid close time "24:00"', async () => {
+    it('rejects hours with an invalid close time "24:00"', async () => {
         const payload = {
             ...validBusinessPayload(),
-            openingHours: { monday: { open: '09:00', close: '24:00' } },
+            hours: [{ dayOfWeek: 'monday', openTime: '09:00', closeTime: '24:00' }],
         };
 
         const response = await request(businessApp).post('/test-business-create').send(payload);
@@ -766,10 +765,10 @@ describe('timePattern integration — businessSchemas.create openingHours', () =
         expect(response.body.errors.some((e: { message: string }) => e.message.includes('HH:MM'))).toBe(true);
     });
 
-    it('rejects openingHours with a single-digit minute "9:0" as close time', async () => {
+    it('rejects hours with a single-digit minute "9:0" as close time', async () => {
         const payload = {
             ...validBusinessPayload(),
-            openingHours: { tuesday: { open: '08:00', close: '9:0' } },
+            hours: [{ dayOfWeek: 'tuesday', openTime: '08:00', closeTime: '9:0' }],
         };
 
         const response = await request(businessApp).post('/test-business-create').send(payload);
@@ -778,7 +777,7 @@ describe('timePattern integration — businessSchemas.create openingHours', () =
         expect(response.body.success).toBe(false);
     });
 
-    it('omitting openingHours entirely is valid (field is optional)', async () => {
+    it('omitting hours entirely is valid (field is optional)', async () => {
         const response = await request(businessApp).post('/test-business-create').send(validBusinessPayload());
 
         expect(response.status).toBe(200);
@@ -788,7 +787,7 @@ describe('timePattern integration — businessSchemas.create openingHours', () =
     it('rejects an invalid open time "25:00" while close time is valid', async () => {
         const payload = {
             ...validBusinessPayload(),
-            openingHours: { wednesday: { open: '25:00', close: '18:00' } },
+            hours: [{ dayOfWeek: 'wednesday', openTime: '25:00', closeTime: '18:00' }],
         };
 
         const response = await request(businessApp).post('/test-business-create').send(payload);

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -31,45 +31,41 @@ const createLocationSchema = (required = false) => {
     return required ? schema.required() : schema.optional();
 };
 
-const createSocialMediaSchema = () =>
-    Joi.object({
-        facebook: commonSchemas.url.optional(),
-        instagram: commonSchemas.url.optional(),
-        twitter: commonSchemas.url.optional(),
-    }).optional();
-
-const createOpeningHoursSchema = () =>
-    Joi.object()
-        .pattern(
-            Joi.string().valid('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'),
-            Joi.object({
-                open: commonSchemas.time.required(),
-                close: commonSchemas.time.required(),
-            })
-        )
-        .optional();
-
 const createBusinessBaseSchema = (isRequired = true) => {
     const schema = {
-        name: Joi.string().trim().min(2).max(100),
+        namePlace: Joi.string().trim().min(2).max(100),
         description: Joi.string().trim().max(1000).optional(),
         address: Joi.string().trim().max(200),
-        phoneNumber: commonSchemas.phone,
-        email: commonSchemas.email.optional(),
-        website: commonSchemas.url.optional(),
-        socialMedia: createSocialMediaSchema(),
-        location: createLocationSchema(isRequired),
-        openingHours: createOpeningHoursSchema(),
+        image: Joi.string().trim().optional(),
+        budget: Joi.number().optional(),
+        contact: Joi.array()
+            .items(
+                Joi.object({
+                    phone: Joi.string().optional(),
+                    email: commonSchemas.email.optional(),
+                    facebook: Joi.string().optional(),
+                    instagram: Joi.string().optional(),
+                })
+            )
+            .optional(),
+        hours: Joi.array()
+            .items(
+                Joi.object({
+                    dayOfWeek: Joi.string().required(),
+                    openTime: commonSchemas.time.required(),
+                    closeTime: commonSchemas.time.required(),
+                })
+            )
+            .optional(),
+        location: createLocationSchema(false),
     };
 
     if (isRequired) {
-        schema.name = schema.name.required();
+        schema.namePlace = schema.namePlace.required();
         schema.address = schema.address.required();
-        schema.phoneNumber = schema.phoneNumber.required();
     } else {
-        schema.name = schema.name.optional();
+        schema.namePlace = schema.namePlace.optional();
         schema.address = schema.address.optional();
-        schema.phoneNumber = schema.phoneNumber.optional();
     }
 
     return schema;
@@ -172,14 +168,15 @@ export const userSchemas = {
 export const businessSchemas = {
     create: Joi.object({
         ...createBusinessBaseSchema(true),
-        category: Joi.string().trim().required(),
+        typeBusiness: Joi.string().trim().required(),
     }),
 
     update: Joi.object({
         ...createBusinessBaseSchema(false),
-        category: Joi.string().trim().optional(),
+        typeBusiness: Joi.string().trim().optional(),
     }),
 
+    // `category` here is a search/filter query param, not a model field — intentionally kept as-is
     search: Joi.object({
         category: Joi.string().trim().optional(),
         latitude: Joi.number().min(-90).max(90).optional(),


### PR DESCRIPTION
## Summary
- Rewrote `createBusinessBaseSchema` to use `namePlace`/`typeBusiness` (matching the model) instead of `name`/`category`
- Connected `validate({ body: businessSchemas.create/update })` middleware on `POST /` and `PUT /:id` (was missing)
- Removed dead helpers `createSocialMediaSchema`/`createOpeningHoursSchema` that mapped to non-existent model fields

## Audit reference
CONTRACT-BIZ — Validator and model had different field names, causing silent 500s from Mongoose validation.

## Known follow-up items (from code review)
- POST/PUT /businesses still missing `rateLimits.api` (SEC-02)
- `image` and `budget` required in model but optional in schema — may need tightening
- Author injection risk in factory — controller does not force `author` from `req.user`

## Test plan
- [x] 30 tests pass in businessControllers.test.ts (unit) + phase1 suite
- [x] tsc --noEmit clean
- [ ] Integration test with valid/invalid bodies