### PR TITLE
fix(reviews): populate correct author fields + PopulatedAuthor type (S3-01)

### DIFF
--- a/src/models/Review.ts
+++ b/src/models/Review.ts
@@ -1,5 +1,17 @@
 import mongoose, { Schema, Types, Document } from 'mongoose';
 
+/**
+ * Shape of the author field after `.populate('author', 'username firstName lastName photo')`.
+ * Use this type in service/controller code that accesses author sub-fields.
+ */
+export interface PopulatedAuthor {
+    _id: Types.ObjectId | string;
+    username: string;
+    firstName?: string;
+    lastName?: string;
+    photo?: string;
+}
+
 export interface IReview extends Document {
     _id: string;
     rating: number;
@@ -8,7 +20,8 @@ export interface IReview extends Document {
     visitDate: Date;
     recommendedDishes?: string[];
     tags?: string[];
-    author: Types.ObjectId;
+    /** Raw ObjectId when un-populated; PopulatedAuthor after `.populate('author', ...)`. */
+    author: Types.ObjectId | PopulatedAuthor;
     // Polymorphic entity fields
     entityType: 'Restaurant' | 'Recipe' | 'Market' | 'Business' | 'Doctor' | 'Sanctuary';
     entity: Types.ObjectId;

--- a/src/services/reviewService/reviewAllQuery.ts
+++ b/src/services/reviewService/reviewAllQuery.ts
@@ -53,7 +53,7 @@ export async function findAllReviews(params: FindAllReviewsParams): Promise<{
 
     const [totalItems, data] = await Promise.all([
         Review.countDocuments(filter),
-        Review.find(filter).populate('author', 'username photo').sort(sortOptions).skip(skip).limit(limit).exec(),
+        Review.find(filter).populate('author', 'username firstName lastName photo').sort(sortOptions).skip(skip).limit(limit).exec(),
     ]);
 
     const totalPages = Math.ceil(totalItems / limit);

--- a/src/services/reviewService/reviewMutations.ts
+++ b/src/services/reviewService/reviewMutations.ts
@@ -60,7 +60,7 @@ export async function addReview(reviewData: Partial<IReview>): Promise<IReview> 
         });
 
         // Fetch populated review for logging
-        const populatedReview = await Review.findById(review._id).populate('author', 'firstName lastName');
+        const populatedReview = await Review.findById(review._id).populate('author', 'username firstName lastName photo');
 
         await invalidateReviewCache(review.entityType, review.entity.toString(), cacheService);
 
@@ -118,7 +118,7 @@ export async function updateReview(reviewId: string, updateData: Partial<IReview
                 session,
                 runValidators: true,
                 context: 'query',
-            }).populate('author', 'firstName lastName');
+            }).populate('author', 'username firstName lastName photo');
             if (!updated) {
                 throw new HttpError(HttpStatusCode.NOT_FOUND, 'Review not found');
             }

--- a/src/services/reviewService/reviewQueries.ts
+++ b/src/services/reviewService/reviewQueries.ts
@@ -59,7 +59,7 @@ export async function getReviewsByEntity(
     sortOptions[sortField] = sortDir;
 
     const [reviews, totalCount] = await Promise.all([
-        Review.find(query).populate('author', 'name').sort(sortOptions).skip(skip).limit(limit),
+        Review.find(query).populate('author', 'username firstName lastName photo').sort(sortOptions).skip(skip).limit(limit),
         Review.countDocuments(query),
     ]);
 
@@ -139,7 +139,7 @@ export async function getReviewById(reviewId: string): Promise<IReview> {
         return cached;
     }
 
-    const review = await Review.findById(reviewId).populate('author', 'name');
+    const review = await Review.findById(reviewId).populate('author', 'username firstName lastName photo');
     if (!review) {
         throw new HttpError(HttpStatusCode.NOT_FOUND, 'Review not found');
     }
@@ -167,7 +167,7 @@ export async function getTopRatedReviews(entityType: string): Promise<IReview[]>
     })
         .sort({ rating: -1, helpfulCount: -1, createdAt: -1 })
         .limit(10)
-        .populate('author', 'name');
+        .populate('author', 'username firstName lastName photo');
 
     await cacheService.setWithTags(cacheKey, reviews, [`reviews:${normalizedType}`, 'top-rated'], 600);
     return reviews;
@@ -187,7 +187,7 @@ export async function listReviewsForModel(entityId: string): Promise<IReview[]> 
     const reviews = await Review.find({
         $or: [{ entity: new Types.ObjectId(entityId) }, { restaurant: new Types.ObjectId(entityId) }],
     })
-        .populate('author', 'name')
+        .populate('author', 'username firstName lastName photo')
         .sort({ createdAt: -1 });
 
     // Always include a stable entity-scoped tag so mutations can invalidate

--- a/src/test/services/reviewService.test.ts
+++ b/src/test/services/reviewService.test.ts
@@ -327,3 +327,83 @@ describe('H-10 — addReview cache tags use committed document fields', () => {
         expect(mockedCache.invalidateByTag).toHaveBeenCalledWith(expect.stringContaining(savedEntityId));
     });
 });
+
+// ---------------------------------------------------------------------------
+// P-01 — populate author fields: username, firstName, lastName, photo
+// Verifies that the populated author returned by addReview and getReviewById
+// always exposes all four required fields.
+// ---------------------------------------------------------------------------
+describe('P-01 — populated author contains username, firstName, lastName, photo', () => {
+    const entityId = '507f1f77bcf86cd799439011';
+    const authorId = '507f1f77bcf86cd799439012';
+
+    const populatedAuthor = {
+        _id: authorId,
+        username: 'jane_doe',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        photo: 'https://cdn.example.com/jane.jpg',
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockedCache.get.mockResolvedValue(null);
+        mockedCache.invalidateByTag.mockResolvedValue(undefined);
+    });
+
+    it('addReview returns a review whose author has username, firstName, lastName, photo', async () => {
+        const committedReview = {
+            _id: '507f1f77bcf86cd799439099',
+            entityType: 'Restaurant',
+            entity: { toString: () => entityId },
+            author: populatedAuthor,
+            rating: 4,
+        };
+
+        mockedReview.findOne.mockResolvedValue(null);
+        mockedReview.create.mockResolvedValue([committedReview]);
+        mockedReview.findById.mockReturnValue({
+            populate: vi.fn().mockResolvedValue(committedReview),
+        });
+
+        const result = await reviewService.addReview({
+            entityType: 'Restaurant',
+            entity: entityId as unknown as never,
+            author: authorId as unknown as never,
+            rating: 4,
+        });
+
+        // The author field must be the populated object, not a raw ObjectId string
+        expect(typeof result.author).toBe('object');
+        const author = result.author as typeof populatedAuthor;
+        expect(author.username).toBe('jane_doe');
+        expect(author.firstName).toBe('Jane');
+        expect(author.lastName).toBe('Doe');
+        expect(author.photo).toBe('https://cdn.example.com/jane.jpg');
+    });
+
+    it('getReviewById returns a review whose author has username, firstName, lastName, photo', async () => {
+        const reviewId = '507f1f77bcf86cd799439055';
+        const storedReview = {
+            _id: reviewId,
+            entityType: 'Recipe',
+            entity: { toString: () => entityId },
+            author: populatedAuthor,
+            rating: 5,
+        };
+
+        mockedReview.findById.mockReturnValue({
+            populate: vi.fn().mockResolvedValue(storedReview),
+        });
+        mockedCache.setWithTags = vi.fn().mockResolvedValue(undefined);
+
+        const result = await reviewService.getReviewById(reviewId);
+
+        expect(typeof result.author).toBe('object');
+        const author = result.author as typeof populatedAuthor;
+        expect(author.username).toBe('jane_doe');
+        expect(author.firstName).toBe('Jane');
+        expect(author.lastName).toBe('Doe');
+        expect(author.photo).toBe('https://cdn.example.com/jane.jpg');
+    });
+});


### PR DESCRIPTION
## Summary
- Replace `populate('author', 'name')` (non-existent field) with `'username firstName lastName photo'` in:
  - reviewQueries.ts (4 locations: getReviewsByEntity, getReviewById, getTopRatedReviews, listReviewsForModel)
  - reviewMutations.ts (2 locations: addReview, updateReview) — **was using inconsistent `'firstName lastName'`**
  - reviewAllQuery.ts (1 location: findAllReviews) — **was using inconsistent `'username photo'`**
- Add `PopulatedAuthor` interface in Review.ts
- Update `IReview.author` type to `Types.ObjectId | PopulatedAuthor`

## Audit reference
BE-16 — `name` field does not exist on User model. Author name was empty in 4+ review queries. Follow-up identified 3 additional inconsistent populates across 3 files.

## Test plan
- [x] 11 tests pass (new P-01 suite + existing reviewService tests)
- [x] tsc --noEmit clean
- [x] grep confirms no other `populate('author', ...)` variants in backend