### PR TITLE
fix(middleware): asyncHandler forwards raw errors to errorHandler (S3-02)

### DIFF
--- a/src/middleware/asyncHandler.ts
+++ b/src/middleware/asyncHandler.ts
@@ -1,19 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
-import { HttpError } from '../types/Errors.js';
 
 type AsyncMiddleware = (req: Request, res: Response, next: NextFunction) => Promise<void>;
 
+/**
+ * Wraps an async route handler so uncaught rejections are forwarded to Express's
+ * error pipeline AS-IS. This preserves error.name / error.code so that the global
+ * errorHandler can branch on Mongoose error types (ValidationError, CastError,
+ * duplicate key 11000) instead of receiving a generic HttpError wrapper.
+ */
 const asyncHandler = (fn: AsyncMiddleware): AsyncMiddleware => {
     return (req, res, next): Promise<void> => {
-        return Promise.resolve(fn(req, res, next)).catch(error => {
-            // If it's already an HttpError, pass it directly
-            if (error instanceof HttpError) {
-                return next(error);
-            }
-            // Otherwise, wrap it in an HttpError
-            const httpError = new HttpError(error.statusCode || 500, error.message || 'Internal Server Error');
-            return next(httpError);
-        });
+        return Promise.resolve(fn(req, res, next)).catch(next);
     };
 };
 


### PR DESCRIPTION
## Summary
Simplify `asyncHandler` from `.catch(wrap-to-HttpError)` to `.catch(next)` so errorHandler can branch on `err.name`/`err.code` for ValidationError, CastError, duplicate key 11000.

## Audit reference
BE-07 — asyncHandler was converting all errors to generic HttpError, causing Mongoose ValidationError/CastError/duplicate-key to reach clients as 500 instead of 400/409 with the correct field info.

## Test plan
- [x] 180 middleware tests pass (errorHandler 19/19, authMiddleware 31/31, etc.)
- [x] tsc --noEmit clean
- [x] Verified errorHandler already has branches for ValidationError/CastError/11000
- [ ] Follow-up: add dedicated asyncHandler.test.ts unit test (currently only ejercitado indirectamente)