### PR TITLE
fix(ci): unblock main security audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "mongodb": "^6.3.0",
                 "mongoose": "^8.15.2",
                 "morgan": "^1.10.0",
-                "nodemailer": "^8.0.4",
+                "nodemailer": "^8.0.5",
                 "redis": "^5.5.6",
                 "swagger-ui-express": "^5.0.1",
                 "uuid": "^13.0.0",
@@ -10198,14 +10198,14 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/b4a": {
@@ -15527,9 +15527,9 @@
             }
         },
         "node_modules/nodemailer": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-            "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+            "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
@@ -16598,10 +16598,13 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "mongodb": "^6.3.0",
         "mongoose": "^8.15.2",
         "morgan": "^1.10.0",
-        "nodemailer": "^8.0.4",
+        "nodemailer": "^8.0.5",
         "redis": "^5.5.6",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^13.0.0",
@@ -157,7 +157,7 @@
     "overrides": {
         "test-exclude": "^7.0.1",
         "brace-expansion": "^2.0.2",
-        "axios": "^1.12.0",
+        "axios": "^1.15.0",
         "dompurify": ">=3.3.3",
         "glob": "^10.5.0",
         "lodash": ">=4.18.0"


### PR DESCRIPTION
## Summary
- bump nodemailer to 8.0.5
- raise the axios override to 1.15.0 so production installs resolve a non-vulnerable tree
- regenerate package-lock.json

## Validation
- npm audit --audit-level critical --omit=dev
- npm ci --omit=dev && npm audit --audit-level critical --omit=dev
- npm run type-check
